### PR TITLE
사용자 관련 API 구현 완료 [김태현]

### DIFF
--- a/mobidic_spring/build.gradle
+++ b/mobidic_spring/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/code/AuthResponseCode.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/code/AuthResponseCode.java
@@ -12,6 +12,11 @@ public enum AuthResponseCode implements ApiResponseCode {
     INVALID_USERNAME(HttpStatus.NOT_FOUND, "Invalid username"),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "Invalid password"),
     JOIN_OK(HttpStatus.OK, "Join success"),
+    LOGOUT_OK(HttpStatus.OK, "Logout success"),
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "Login failed"),
+    LOGOUT_FAILED(HttpStatus.BAD_REQUEST, "Logout failed"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "Invalid token"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "Unauthorized"),
     LOGIN_OK(HttpStatus.OK, "Login success");
 
     private final HttpStatus status;

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/code/GeneralResponseCode.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/code/GeneralResponseCode.java
@@ -21,7 +21,6 @@ public enum GeneralResponseCode implements ApiResponseCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "Method is not supported"),
     INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "Invalid request Body"),
     FORBIDDEN(HttpStatus.FORBIDDEN, "Forbidden request"),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "Invalid token"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error");
 
     private final HttpStatus status;

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/config/RedisConfig.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/config/RedisConfig.java
@@ -1,0 +1,29 @@
+package com.kimtaeyang.mobidic.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+}

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/config/SecurityConfig.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.kimtaeyang.mobidic.config;
 
+import com.kimtaeyang.mobidic.exception.AuthAccessDeniedHandler;
+import com.kimtaeyang.mobidic.exception.AuthAuthenticationEntryPoint;
 import com.kimtaeyang.mobidic.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -21,6 +23,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final AuthAuthenticationEntryPoint authAuthenticationEntryPoint;
+    private final AuthAccessDeniedHandler authAccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -32,13 +36,13 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/login", "/api/auth/join").permitAll()
+                        .requestMatchers("/error").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .logout(logout -> logout
-                        .logoutUrl("/logout")
-                        .logoutSuccessUrl("/login")
-                        .permitAll()
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .authenticationEntryPoint(authAuthenticationEntryPoint)
+                        .accessDeniedHandler(authAccessDeniedHandler)
                 );
 
         return http.build();

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/controller/AuthController.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.kimtaeyang.mobidic.dto.ApiResponse;
 import com.kimtaeyang.mobidic.dto.JoinDto;
 import com.kimtaeyang.mobidic.dto.LoginDto;
 import com.kimtaeyang.mobidic.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,8 +13,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.kimtaeyang.mobidic.code.AuthResponseCode.JOIN_OK;
-import static com.kimtaeyang.mobidic.code.AuthResponseCode.LOGIN_OK;
+import java.util.UUID;
+
+import static com.kimtaeyang.mobidic.code.AuthResponseCode.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,5 +32,13 @@ public class AuthController {
     public ResponseEntity<?> join(@Valid @RequestBody JoinDto.Request request) {
         authService.join(request);
         return ApiResponse.toResponseEntity(JOIN_OK, null);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(HttpServletRequest request) {
+        String token = request.getHeader("Authorization").substring(7);
+
+        authService.logout(UUID.fromString(token));
+        return ApiResponse.toResponseEntity(LOGOUT_OK, null);
     }
 }

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/controller/MemberController.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/controller/MemberController.java
@@ -1,0 +1,72 @@
+package com.kimtaeyang.mobidic.controller;
+
+import com.kimtaeyang.mobidic.dto.ApiResponse;
+import com.kimtaeyang.mobidic.dto.UpdateNicknameDto;
+import com.kimtaeyang.mobidic.dto.UpdatePasswordDto;
+import com.kimtaeyang.mobidic.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+import static com.kimtaeyang.mobidic.code.GeneralResponseCode.OK;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/user")
+public class MemberController {
+    private final MemberService memberService;
+
+    @GetMapping("/detail/{memberId}")
+    public ResponseEntity<?> getMemberDetail(
+            @PathVariable @Valid String memberId
+    ) {
+        return ApiResponse.toResponseEntity(OK,
+                memberService.getMemberDetailById(UUID.fromString(memberId)));
+    }
+
+    @PatchMapping("/nckchn/{memberId}")
+    public ResponseEntity<?> updateMemberNickname(
+            @PathVariable String memberId,
+            @RequestBody @Valid UpdateNicknameDto.Request request
+    ) {
+        return ApiResponse.toResponseEntity(OK,
+                memberService.updateMemberNickname(UUID.fromString(memberId), request));
+    }
+
+    @PatchMapping("/pschn/{memberId}")
+    public ResponseEntity<?> updateMemberPassword(
+            @PathVariable String memberId,
+            @RequestBody @Valid UpdatePasswordDto.Request request
+    ){
+        return ApiResponse.toResponseEntity(OK,
+                memberService.updateMemberPassword(UUID.fromString(memberId), request));
+    }
+
+    @PatchMapping("/withdraw/{memberId}")
+    public ResponseEntity<?> withdrawMember(
+            @PathVariable String memberId,
+            HttpServletRequest request
+    ){
+        String token = request.getHeader("Authorization").substring(7);
+
+        return ApiResponse.toResponseEntity(OK,
+                memberService.withdrawMember(token, UUID.fromString(memberId)));
+    }
+
+    @DeleteMapping("/delete/{memberId}")
+    public ResponseEntity<?> deleteMember(
+            @PathVariable String memberId,
+            HttpServletRequest request
+    ){
+        String token = request.getHeader("Authorization").substring(7);
+
+        return ApiResponse.toResponseEntity(OK,
+                memberService.deleteMember(token, UUID.fromString(memberId)));
+    }
+}

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/MemberDto.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/MemberDto.java
@@ -1,0 +1,30 @@
+package com.kimtaeyang.mobidic.dto;
+
+import com.kimtaeyang.mobidic.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberDto {
+    private UUID id;
+    private String email;
+    private String nickname;
+    private Timestamp createdAt;
+
+    public static MemberDto fromEntity(Member member) {
+        return MemberDto.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .createdAt(member.getCreatedAt())
+                .build();
+    }
+}

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/UpdateNicknameDto.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/UpdateNicknameDto.java
@@ -1,41 +1,31 @@
 package com.kimtaeyang.mobidic.dto;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-public class JoinDto {
+import java.util.UUID;
+
+public class UpdateNicknameDto {
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    public static class Request{
-        @NotBlank
-        @Size(min = 2, max = 100)
-        @Email
-        private String email;
-
+    public static class Request {
         @NotBlank
         @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9-_]{2,16}$")
         private String nickname;
-
-        @NotBlank
-        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,128}$")
-        //최소 8자, 숫자와 알파벳
-        private String password;
     }
 
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    public static class Response{
-        private String email;
+    public static class Response {
+        private UUID id;
         private String nickname;
     }
 }

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/UpdatePasswordDto.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/UpdatePasswordDto.java
@@ -1,29 +1,20 @@
 package com.kimtaeyang.mobidic.dto;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-public class JoinDto {
+import java.util.UUID;
+
+public class UpdatePasswordDto {
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    public static class Request{
-        @NotBlank
-        @Size(min = 2, max = 100)
-        @Email
-        private String email;
-
-        @NotBlank
-        @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9-_]{2,16}$")
-        private String nickname;
-
+    public static class Request {
         @NotBlank
         @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,128}$")
         //최소 8자, 숫자와 알파벳
@@ -34,8 +25,7 @@ public class JoinDto {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    public static class Response{
-        private String email;
-        private String nickname;
+    public static class Response {
+        private UUID id;
     }
 }

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/WithdrawMemberDto.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/WithdrawMemberDto.java
@@ -1,0 +1,21 @@
+package com.kimtaeyang.mobidic.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+
+public class WithdrawMemberDto {
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Response {
+        private String email;
+        private String nickname;
+        private Timestamp createdAt;
+        private Timestamp withdrawnAt;
+    }
+}

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/entity/Member.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/entity/Member.java
@@ -29,8 +29,12 @@ public class Member implements UserDetails {
     private String nickname;
     @Column(name="password")
     private String password;
+    @Column(name="is_active", insertable=false)
+    private Boolean isActive;
     @Column(name="created_at", insertable = false, updatable = false)
     private Timestamp createdAt;
+    @Column(name="withdrawn_at")
+    private Timestamp withdrawnAt;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/exception/ApiExceptionHandler.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/exception/ApiExceptionHandler.java
@@ -7,12 +7,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import static com.kimtaeyang.mobidic.code.AuthResponseCode.INVALID_PASSWORD;
-import static com.kimtaeyang.mobidic.code.AuthResponseCode.INVALID_USERNAME;
+import static com.kimtaeyang.mobidic.code.AuthResponseCode.*;
+import static com.kimtaeyang.mobidic.code.GeneralResponseCode.FORBIDDEN;
 import static com.kimtaeyang.mobidic.code.GeneralResponseCode.INTERNAL_SERVER_ERROR;
 
 @Slf4j
@@ -30,17 +31,36 @@ public class ApiExceptionHandler {
         return ApiResponse.toResponseEntity(INTERNAL_SERVER_ERROR, null);
     }
 
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<?> methodNotSupported(
+            HttpRequestMethodNotSupportedException e, HttpServletRequest request
+    ) {
+        log.error("errorCode : {}, uri : {}, message : {}",
+                e, request.getRequestURI(), e.getMessage());
+        return ApiResponse.toResponseEntity(FORBIDDEN, null);
+    }
+
     @ExceptionHandler(BadCredentialsException.class)
     public ResponseEntity<?> badCredentials(
             BadCredentialsException e, HttpServletRequest request
     ) {
         log.error("errorCode : {}, uri : {}, message : {}",
                 e, request.getRequestURI(), e.getMessage());
-        return ApiResponse.toResponseEntity(INVALID_PASSWORD, null);
+        return ApiResponse.toResponseEntity(LOGIN_FAILED, null);
+    }
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<?> apiException(
+            ApiException e, HttpServletRequest request
+    ) {
+        log.error("errorCode : {}, uri : {}, message : {}",
+                e, request.getRequestURI(), e.getMessage());
+
+        return ApiResponse.toResponseEntity(e.getResponseCode(), null);
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<?> handleCustomException(
+    public ResponseEntity<?> exception(
             Exception e, HttpServletRequest request
     ) {
         log.error("errorCode : {}, uri : {}, message : {}",

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/exception/AuthAccessDeniedHandler.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/exception/AuthAccessDeniedHandler.java
@@ -1,0 +1,44 @@
+package com.kimtaeyang.mobidic.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kimtaeyang.mobidic.dto.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.kimtaeyang.mobidic.code.GeneralResponseCode.FORBIDDEN;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class AuthAccessDeniedHandler implements AccessDeniedHandler {
+    //403
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        log.error("errorCode : {}, uri : {}, message : {}",
+                accessDeniedException, request.getRequestURI(), accessDeniedException   .getMessage());
+
+        ApiResponse<?> apiResponse = ApiResponse.builder()
+                .data(null)
+                .status(FORBIDDEN.getStatus().value())
+                .message(FORBIDDEN.getMessage())
+                .build();
+        String responseBody = objectMapper.writeValueAsString(apiResponse);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(FORBIDDEN.getStatus().value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+}

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/exception/AuthAuthenticationEntryPoint.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/exception/AuthAuthenticationEntryPoint.java
@@ -1,0 +1,45 @@
+package com.kimtaeyang.mobidic.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kimtaeyang.mobidic.dto.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.kimtaeyang.mobidic.code.AuthResponseCode.UNAUTHORIZED;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class AuthAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    //401
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        log.error("errorCode : {}, uri : {}, message : {}",
+                authException, request.getRequestURI(), authException.getMessage());
+
+        ApiResponse<?> apiResponse = ApiResponse.builder()
+                .data(null)
+                .status(UNAUTHORIZED.getStatus().value())
+                .message(UNAUTHORIZED.getMessage())
+                .build();
+
+        String responseBody = objectMapper.writeValueAsString(apiResponse);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(UNAUTHORIZED.getStatus().value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+}

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/JwtBlacklistService.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/JwtBlacklistService.java
@@ -1,0 +1,56 @@
+package com.kimtaeyang.mobidic.security;
+
+import com.kimtaeyang.mobidic.exception.ApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+import static com.kimtaeyang.mobidic.code.AuthResponseCode.INVALID_TOKEN;
+
+@Service
+@RequiredArgsConstructor
+public class JwtBlacklistService {
+    private final RedisTemplate<String, String> redisTemplate;
+    private final JwtUtil jwtUtil;
+    private static final String LOGOUT_PREFIX = "logout:";
+    private static final String WITHDRAWN_PREFIX = "withdraw:";
+    @Value("${jwt.exp}")
+    private Long exp;
+
+    public void logoutToken(String token) {
+        long remain = jwtUtil.getExpirationFromToken(token).getTime() - System.currentTimeMillis();
+
+        if(isTokenLogout(token)) {
+            throw new ApiException(INVALID_TOKEN);
+        }
+
+        redisTemplate.opsForValue().set(
+                LOGOUT_PREFIX + token,
+                "true",
+                Duration.ofMillis(remain)
+        );
+    }
+
+    public void withdrawToken(String token) {
+        if(isTokenLogout(token)) {
+            throw new ApiException(INVALID_TOKEN);
+        }
+
+        redisTemplate.opsForValue().set(
+                WITHDRAWN_PREFIX + jwtUtil.getIdFromToken(token),
+                "true",
+                Duration.ofMillis(exp)
+        );
+    }
+
+    public boolean isTokenLogout(String token) {
+        return redisTemplate.hasKey(LOGOUT_PREFIX + token);
+    }
+
+    public boolean isTokenWithdrawn(String token) {
+        return redisTemplate.hasKey(WITHDRAWN_PREFIX + jwtUtil.getIdFromToken(token));
+    }
+}

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/JwtUtil.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/JwtUtil.java
@@ -47,4 +47,14 @@ public class JwtUtil {
                 .getPayload();
         return UUID.fromString(claims.getSubject());
     }
+
+    public Date getExpirationFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(jwtProperties.getSecretKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return claims.getExpiration();
+    }
 }

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/UserDetailsServiceImpl.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/UserDetailsServiceImpl.java
@@ -1,6 +1,6 @@
 package com.kimtaeyang.mobidic.security;
 
-import com.kimtaeyang.mobidic.exception.ApiException;
+import com.kimtaeyang.mobidic.entity.Member;
 import com.kimtaeyang.mobidic.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -17,7 +17,13 @@ public class UserDetailsServiceImpl  implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        return memberRepository.findByEmail(email)
-                .orElseThrow(() -> new ApiException(NO_MEMBER, NO_MEMBER.getMessage() + email));
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException(NO_MEMBER.getMessage()));
+
+        if(!member.getIsActive()){
+            throw new UsernameNotFoundException(NO_MEMBER.getMessage());
+        }
+
+        return member;
     }
 }

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/AuthService.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/AuthService.java
@@ -4,23 +4,30 @@ import com.kimtaeyang.mobidic.dto.JoinDto;
 import com.kimtaeyang.mobidic.dto.LoginDto;
 import com.kimtaeyang.mobidic.entity.Member;
 import com.kimtaeyang.mobidic.repository.MemberRepository;
+import com.kimtaeyang.mobidic.security.JwtBlacklistService;
 import com.kimtaeyang.mobidic.security.JwtUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class AuthService {
     private final AuthenticationManager authenticationManager;
     private final MemberRepository memberRepository;
     private final JwtUtil jwtUtil;
     private final PasswordEncoder passwordEncoder;
+    private final JwtBlacklistService jwtBlacklistService;
 
     @Transactional(readOnly = true)
     public String login(LoginDto.Request request) {
@@ -37,9 +44,16 @@ public class AuthService {
     public void join(@Valid JoinDto.Request request) {
         Member member = Member.builder()
                 .email(request.getEmail())
-                .nickname(request.getUsername())
+                .nickname(request.getNickname())
                 .password(passwordEncoder.encode(request.getPassword()))
                 .build();
         memberRepository.save(member);
+    }
+
+    public void logout(UUID token) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        auth.setAuthenticated(false);
+
+        jwtBlacklistService.logoutToken(token.toString());
     }
 }

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/MemberService.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/MemberService.java
@@ -1,0 +1,126 @@
+package com.kimtaeyang.mobidic.service;
+
+import com.kimtaeyang.mobidic.dto.MemberDto;
+import com.kimtaeyang.mobidic.dto.UpdateNicknameDto;
+import com.kimtaeyang.mobidic.dto.UpdatePasswordDto;
+import com.kimtaeyang.mobidic.dto.WithdrawMemberDto;
+import com.kimtaeyang.mobidic.entity.Member;
+import com.kimtaeyang.mobidic.exception.ApiException;
+import com.kimtaeyang.mobidic.repository.MemberRepository;
+import com.kimtaeyang.mobidic.security.JwtBlacklistService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static com.kimtaeyang.mobidic.code.AuthResponseCode.NO_MEMBER;
+import static com.kimtaeyang.mobidic.code.AuthResponseCode.UNAUTHORIZED;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtBlacklistService jwtBlacklistService;
+
+    @Transactional(readOnly = true)
+    public MemberDto getMemberDetailById(UUID memberId) {
+        authorizeMember(memberId);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApiException(NO_MEMBER));
+
+        return MemberDto.fromEntity(member);
+    }
+
+    @Transactional
+    public UpdateNicknameDto.Response updateMemberNickname(
+            UUID memberId, UpdateNicknameDto.Request request
+    ) {
+        authorizeMember(memberId);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApiException(NO_MEMBER));
+        member.setNickname(request.getNickname());
+        memberRepository.save(member);
+
+        return UpdateNicknameDto.Response.builder()
+                .nickname(member.getNickname())
+                .id(member.getId())
+                .build();
+    }
+
+    @Transactional
+    public UpdatePasswordDto.Response updateMemberPassword(
+            UUID memberId, UpdatePasswordDto.Request request
+    ) {
+        authorizeMember(memberId);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApiException(NO_MEMBER));
+
+        member.setPassword(passwordEncoder.encode(request.getPassword()));
+        memberRepository.save(member);
+
+        return UpdatePasswordDto.Response.builder()
+                .id(member.getId())
+                .build();
+    }
+
+    @Transactional
+    public WithdrawMemberDto.Response withdrawMember(String token, UUID memberId) {
+        authorizeMember(memberId);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApiException(NO_MEMBER));
+
+        member.setWithdrawnAt(Timestamp.valueOf(LocalDateTime.now()));
+        member.setIsActive(false);
+        memberRepository.save(member);
+
+        jwtBlacklistService.withdrawToken(token);
+        SecurityContextHolder.clearContext();
+
+        return WithdrawMemberDto.Response.builder()
+                .withdrawnAt(member.getWithdrawnAt())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .createdAt(member.getCreatedAt())
+                .build();
+    }
+
+    @Transactional
+    public WithdrawMemberDto.Response deleteMember(String token, UUID memberId) {
+        authorizeMember(memberId);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApiException(NO_MEMBER));
+        memberRepository.deleteById(memberId);
+
+        jwtBlacklistService.withdrawToken(token);
+        SecurityContextHolder.clearContext();
+
+        return WithdrawMemberDto.Response.builder()
+                .createdAt(member.getCreatedAt())
+                .withdrawnAt(Timestamp.valueOf(LocalDateTime.now()))
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .build();
+    }
+
+    private void authorizeMember(UUID memberId) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        UUID currentId = ((Member) auth.getPrincipal()).getId();
+        if (!memberId.equals(currentId)) {
+            throw new ApiException(UNAUTHORIZED);
+        }
+    }
+}

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/http/join.http
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/http/join.http
@@ -1,0 +1,9 @@
+### Send POST request with json body
+POST http://127.0.0.1:8080/api/auth/join
+Content-Type: application/json
+
+{
+  "email" : "testMember2@email.com",
+  "nickname": "testmember1",
+  "password": "testmember1"
+}

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/http/login.http
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/http/login.http
@@ -1,0 +1,8 @@
+### Send POST request with json body
+POST http://127.0.0.1:8080/api/auth/login
+Content-Type: application/json
+
+{
+  "email" : "testMember2@email.com",
+  "password": "testmember1"
+}

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/http/user_delete.http
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/http/user_delete.http
@@ -1,0 +1,8 @@
+DELETE http://127.0.0.1:8080/api/user/delete/9c857422-3e6d-4f66-a33e-5a16bdd3b8b8
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiI5Yzg1NzQyMi0zZTZkLTRmNjYtYTMzZS01YTE2YmRkM2I4YjgiLCJpYXQiOjE3NDM4NTI2MDgsImV4cCI6MTc0MzkzOTAwOH0.UvMBcRv5s6spd4HxBUICAxchH2S6ZoRuuEF1kPkXaGQ45n4ylaLqGAr2yQyHs7Z1ZAPhjA5qyETefU6kii2WbA
+
+{
+  "email" : "testMember2@email.com",
+  "password": "testMember1"
+}

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/http/user_detail.http
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/http/user_detail.http
@@ -1,0 +1,4 @@
+### Send PATCH request with json body
+GET http://127.0.0.1:8080/api/user/detail/a1f108c5-f266-41aa-92e4-b85a4366e501
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhMWYxMDhjNS1mMjY2LTQxYWEtOTJlNC1iODVhNDM2NmU1MDEiLCJpYXQiOjE3NDM4NTEzOTEsImV4cCI6MTc0MzkzNzc5MX0.scFltAWfvELA1xIl2_0f8gJafvVDZ50Vmt07X8Wi_K7sDZ4-bA3cwF8K5fd65zG2qYRSSs3a3X-WVarYtr7PGg

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/http/withdraw.http
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/http/withdraw.http
@@ -1,0 +1,5 @@
+### Send PATCH request with json body
+PATCH http://127.0.0.1:8080/api/user/withdraw/a1f108c5-f266-41aa-92e4-b85a4366e501
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhMWYxMDhjNS1mMjY2LTQxYWEtOTJlNC1iODVhNDM2NmU1MDEiLCJpYXQiOjE3NDM4NTEzNzYsImV4cCI6MTc0MzkzNzc3Nn0.SwiKfAsjIzOO1AChNWu_dsGSchmmtUe_P0k1EuiJ1sKvDoMXGEJu914L989bJuDI3TPWFvKlBd1m-eXGVbZ5YQ
+


### PR DESCRIPTION
로그아웃 및 회원탈퇴 구현, Spring Security Exception handling
- Redis로 Logout, 회원탈퇴 시 해당 JWT를 Blaciklist에 등록하여 Authentication Filter에서 Redis 조회 후 해당하면 인증 실패
- 회원탈퇴 시 별도의 Prefix 사용해서 UUID 자체를 저장하고 이후 들어오는 JWT의 signature 파싱하여 해당하면 인증 실패
- 서비스 레이어에서 사용자 검증 시 해당 계정 활성화 여부 검증 로직 추가
- Spring Security의 처리 과정은 Spring Context에 포함되지 않으므로 별도의 Exception Handler 구현
- 전역 Exception handler 예외 처리 추가

사용자 관련 API 구현 완료
- JWT 토큰 인증, 서비스 레이어에서 사용자 검증
- 회원가입, 로그인, 로그아웃, 회원탈퇴 API 구현
- 사용자 디테일 조회, 비밀번호 변경, 닉네임 변경 API 구현
- 사용자 완전 삭제 API는 관리자용으로, 프론트 개발 시 사용 X