### PR TITLE
Data ownership validation 로직 관련 access handler 추가 [김태현]

### DIFF
--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/config/SecurityConfig.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -21,6 +22,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final AuthAuthenticationEntryPoint authAuthenticationEntryPoint;

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/controller/AuthController.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.kimtaeyang.mobidic.controller;
 import com.kimtaeyang.mobidic.dto.ApiResponse;
 import com.kimtaeyang.mobidic.dto.JoinDto;
 import com.kimtaeyang.mobidic.dto.LoginDto;
+import com.kimtaeyang.mobidic.security.JwtUtil;
 import com.kimtaeyang.mobidic.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -22,6 +23,7 @@ import static com.kimtaeyang.mobidic.code.AuthResponseCode.*;
 @RequestMapping("/api/auth")
 public class AuthController {
     private final AuthService authService;
+    private final JwtUtil jwtUtil;
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@Valid @RequestBody LoginDto.Request request) {
@@ -36,7 +38,8 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<?> logout(HttpServletRequest request) {
         String token = request.getHeader("Authorization").substring(7);
+        UUID memberId = jwtUtil.getIdFromToken(token);
 
-        return ApiResponse.toResponseEntity(LOGOUT_OK, authService.logout(UUID.fromString(token)));
+        return ApiResponse.toResponseEntity(LOGOUT_OK, authService.logout(memberId, token));
     }
 }

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/controller/MemberController.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/controller/MemberController.java
@@ -22,12 +22,12 @@ import static com.kimtaeyang.mobidic.code.GeneralResponseCode.OK;
 public class MemberController {
     private final MemberService memberService;
 
-    @GetMapping("/detail/{memberId}")
+    @GetMapping("/detail")
     public ResponseEntity<?> getMemberDetail(
-            @PathVariable @Valid String memberId
+            @RequestParam @Valid String uId
     ) {
         return ApiResponse.toResponseEntity(OK,
-                memberService.getMemberDetailById(UUID.fromString(memberId)));
+                memberService.getMemberDetailById(UUID.fromString(uId)));
     }
 
     @PatchMapping("/nckchn/{memberId}")

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/exception/ApiExceptionHandler.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/exception/ApiExceptionHandler.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -47,6 +48,15 @@ public class ApiExceptionHandler {
         log.error("errorCode : {}, uri : {}, message : {}",
                 e, request.getRequestURI(), e.getMessage());
         return ApiResponse.toResponseEntity(LOGIN_FAILED, null);
+    }
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<?> authorizationDenied(
+            AuthorizationDeniedException e, HttpServletRequest request
+    ) {
+        log.error("errorCode : {}, uri : {}, message : {}",
+                e, request.getRequestURI(), e.getMessage());
+        return ApiResponse.toResponseEntity(UNAUTHORIZED, null);
     }
 
     @ExceptionHandler(ApiException.class)

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/AccessHandler.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/AccessHandler.java
@@ -1,0 +1,19 @@
+package com.kimtaeyang.mobidic.security;
+
+import com.kimtaeyang.mobidic.entity.Member;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.UUID;
+
+public abstract class AccessHandler {
+    public final boolean ownershipCheck(UUID resourceId) {
+        return isResourceOwner(resourceId);
+    }
+
+    public final UUID getCurrentMemberId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        return ((Member) auth.getPrincipal()).getId();
+    }
+    abstract boolean isResourceOwner(UUID resourceId);
+}

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/DefAccessHandler.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/DefAccessHandler.java
@@ -1,0 +1,28 @@
+package com.kimtaeyang.mobidic.security;
+
+import com.kimtaeyang.mobidic.entity.Def;
+import com.kimtaeyang.mobidic.entity.Vocab;
+import com.kimtaeyang.mobidic.entity.Word;
+import com.kimtaeyang.mobidic.repository.DefRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DefAccessHandler extends AccessHandler {
+    private final DefRepository defRepository;
+
+    @Override
+    boolean isResourceOwner(UUID resourceId) {
+        return defRepository.findById(resourceId)
+                .map(Def::getWord)
+                .map(Word::getVocab)
+                .map(Vocab::getMember)
+                .filter((m) -> getCurrentMemberId().equals(m.getId()))
+                .isPresent();
+    }
+}

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/MemberAccessHandler.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/MemberAccessHandler.java
@@ -1,0 +1,24 @@
+package com.kimtaeyang.mobidic.security;
+
+import com.kimtaeyang.mobidic.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberAccessHandler extends AccessHandler {
+    private final MemberRepository memberRepository;
+
+    @Override
+    boolean isResourceOwner(UUID resourceId) {
+        return memberRepository.findById(resourceId)
+                .filter((m) -> getCurrentMemberId().equals(resourceId))
+                .isPresent();
+    }
+}

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/RateAccessHandler.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/RateAccessHandler.java
@@ -1,0 +1,28 @@
+package com.kimtaeyang.mobidic.security;
+
+import com.kimtaeyang.mobidic.entity.Rate;
+import com.kimtaeyang.mobidic.entity.Vocab;
+import com.kimtaeyang.mobidic.entity.Word;
+import com.kimtaeyang.mobidic.repository.RateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RateAccessHandler extends AccessHandler {
+    private final RateRepository rateRepository;
+
+    @Override
+    boolean isResourceOwner(UUID resourceId) {
+        return rateRepository.findById(resourceId)
+                .map(Rate::getWord)
+                .map(Word::getVocab)
+                .map(Vocab::getMember)
+                .filter((m) -> getCurrentMemberId().equals(m.getId()))
+                .isPresent();
+    }
+}

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/VocabAccessHandler.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/VocabAccessHandler.java
@@ -1,0 +1,26 @@
+package com.kimtaeyang.mobidic.security;
+
+import com.kimtaeyang.mobidic.entity.Vocab;
+import com.kimtaeyang.mobidic.repository.VocabRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class VocabAccessHandler extends AccessHandler {
+    private final VocabRepository vocabRepository;
+
+    @Override
+    boolean isResourceOwner(UUID resourceId) {
+        return vocabRepository.findById(resourceId)
+                .map(Vocab::getMember)
+                .filter((m) -> getCurrentMemberId().equals(m.getId()))
+                .isPresent();
+    }
+}

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/WordAccessHandler.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/security/WordAccessHandler.java
@@ -1,0 +1,26 @@
+package com.kimtaeyang.mobidic.security;
+
+import com.kimtaeyang.mobidic.entity.Vocab;
+import com.kimtaeyang.mobidic.entity.Word;
+import com.kimtaeyang.mobidic.repository.WordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WordAccessHandler extends AccessHandler {
+    private final WordRepository wordRepository;
+
+    @Override
+    boolean isResourceOwner(UUID resourceId) {
+        return wordRepository.findById(resourceId)
+                .map(Word::getVocab)
+                .map(Vocab::getMember)
+                .filter((m) -> getCurrentMemberId().equals(m.getId()))
+                .isPresent();
+    }
+}

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/DefService.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/DefService.java
@@ -3,15 +3,13 @@ package com.kimtaeyang.mobidic.service;
 import com.kimtaeyang.mobidic.dto.AddDefDto;
 import com.kimtaeyang.mobidic.dto.DefDto;
 import com.kimtaeyang.mobidic.entity.Def;
-import com.kimtaeyang.mobidic.entity.Member;
 import com.kimtaeyang.mobidic.entity.Word;
 import com.kimtaeyang.mobidic.exception.ApiException;
 import com.kimtaeyang.mobidic.repository.DefRepository;
 import com.kimtaeyang.mobidic.repository.WordRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,7 +17,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static com.kimtaeyang.mobidic.code.AuthResponseCode.UNAUTHORIZED;
 import static com.kimtaeyang.mobidic.code.GeneralResponseCode.*;
 
 @Service
@@ -30,10 +27,10 @@ public class DefService {
     private final DefRepository defRepository;
 
     @Transactional
+    @PreAuthorize("@wordAccessHandler.ownershipCheck(#wordId)")
     public AddDefDto.Response addDef(UUID wordId, AddDefDto.Request request) {
         Word word = wordRepository.findById(wordId)
                 .orElseThrow(() -> new ApiException(NO_WORD));
-        authorizeWord(word);
 
         defRepository.findByDefinition(request.getDefinition())
                 .ifPresent((d) -> {
@@ -50,11 +47,11 @@ public class DefService {
         return AddDefDto.Response.fromEntity(def);
     }
 
+    @PreAuthorize("@wordAccessHandler.ownershipCheck(#wordId)")
     @Transactional(readOnly = true)
     public List<DefDto> getDefsByWordId(UUID wordId) {
         Word word = wordRepository.findById(wordId)
                 .orElseThrow(() -> new ApiException(NO_WORD));
-        authorizeWord(word);
 
         return defRepository.findByWord(word)
                 .stream().map(DefDto::fromEntity)
@@ -62,10 +59,10 @@ public class DefService {
     }
 
     @Transactional
+    @PreAuthorize("@defAccessHandler.ownershipCheck(#defId)")
     public AddDefDto.Response updateDef(UUID defId, AddDefDto.Request request) {
         Def def = defRepository.findById(defId)
                 .orElseThrow(() -> new ApiException(NO_DEF));
-        authorizeDef(def);
 
         defRepository.findByDefinition(request.getDefinition())
                 .ifPresent((d) -> { throw new ApiException(DUPLICATED_DEFINITION); });
@@ -78,31 +75,13 @@ public class DefService {
     }
 
     @Transactional
+    @PreAuthorize("@defAccessHandler.ownershipCheck(#defId)")
     public DefDto deleteDef(UUID defId) {
         Def def = defRepository.findById(defId)
                 .orElseThrow(() -> new ApiException(NO_DEF));
-        authorizeDef(def);
 
         defRepository.delete(def);
 
         return DefDto.fromEntity(def);
-    }
-
-    private void authorizeDef(Def def) {
-        if (!def.getWord().getVocab().getMember().getId().equals(getCurrentMemberId())) {
-            throw new ApiException(UNAUTHORIZED);
-        }
-    }
-
-    private void authorizeWord(Word word) {
-        if (!word.getVocab().getMember().getId().equals(getCurrentMemberId())) {
-            throw new ApiException(UNAUTHORIZED);
-        }
-    }
-
-    private UUID getCurrentMemberId() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-
-        return ((Member) auth.getPrincipal()).getId();
     }
 }

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/RateService.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/RateService.java
@@ -1,55 +1,48 @@
 package com.kimtaeyang.mobidic.service;
 
 import com.kimtaeyang.mobidic.dto.RateDto;
-import com.kimtaeyang.mobidic.entity.Member;
 import com.kimtaeyang.mobidic.entity.Rate;
-import com.kimtaeyang.mobidic.entity.Vocab;
 import com.kimtaeyang.mobidic.exception.ApiException;
 import com.kimtaeyang.mobidic.repository.RateRepository;
 import com.kimtaeyang.mobidic.repository.VocabRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
-import static com.kimtaeyang.mobidic.code.AuthResponseCode.UNAUTHORIZED;
-import static com.kimtaeyang.mobidic.code.GeneralResponseCode.*;
+import static com.kimtaeyang.mobidic.code.GeneralResponseCode.INTERNAL_SERVER_ERROR;
+import static com.kimtaeyang.mobidic.code.GeneralResponseCode.NO_RATE;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class RateService {
     private final RateRepository rateRepository;
-    private final VocabRepository vocabRepository;
 
     @Transactional(readOnly = true)
+    @PreAuthorize("@rateAccessHandler.ownershipCheck(#wordId)")
     public RateDto getRateByWordId(UUID wordId) {
         Rate rate = rateRepository.getRateByWordId(wordId)
                 .orElseThrow(() -> new ApiException(NO_RATE));
-        authorizeRate(rate);
 
         return RateDto.fromEntity(rate);
     }
 
+    @PreAuthorize("@vocabAccessHandler.ownershipCheck(#vocabId)")
     @Transactional(readOnly = true)
     public Double getVocabLearningRate(UUID vocabId) {
-        Vocab vocab = vocabRepository.findById(vocabId)
-                .orElseThrow(() -> new ApiException(NO_VOCAB));
-        authorizeVocab(vocab);
-
         return rateRepository.getVocabLearningRate(vocabId)
                 .orElseThrow(() -> new ApiException(INTERNAL_SERVER_ERROR));
     }
 
     @Transactional
+    @PreAuthorize("@wordAccessHandler.ownershipCheck(#wordId)")
     public void toggleRateByWordId(UUID wordId) {
         Rate rate = rateRepository.getRateByWordId(wordId)
                 .orElseThrow(() -> new ApiException(NO_RATE));
-        authorizeRate(rate);
 
         if(rate.getIsLearned() > 0){
             rate.setIsLearned(0);
@@ -58,23 +51,5 @@ public class RateService {
         }
 
         rateRepository.save(rate);
-    }
-
-    private void authorizeVocab(Vocab vocab) {
-        if (!vocab.getMember().getId().equals(getCurrentMemberId())) {
-            throw new ApiException(UNAUTHORIZED);
-        }
-    }
-
-    private void authorizeRate(Rate rate) {
-        if (!rate.getWord().getVocab().getMember().getId().equals(getCurrentMemberId())) {
-            throw new ApiException(UNAUTHORIZED);
-        }
-    }
-
-    private UUID getCurrentMemberId() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-
-        return ((Member) auth.getPrincipal()).getId();
     }
 }


### PR DESCRIPTION
[refactor: Data ownership validation 로직 관련 access handler 추가]
- Access Handler 인터페이스 및 구현체를 통해 AOP 기반 데이터 소유권 검증으로 로직 변경

[fix: API URI 수정]
- GET /api/user/detail/{UUID} -> /api/user/detail?uId={UUID}