### PR TITLE
Member, Vocab, Word 서비스 Unit Test [김태현]

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="FrameworkDetectionExcludesConfiguration">
-    <file type="web" url="file://$PROJECT_DIR$/mobidic_spring" />
-  </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
-    <output url="file://$PROJECT_DIR$/out" />
-  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,7 +3,6 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/mobidic.main.iml" filepath="$PROJECT_DIR$/.idea/modules/mobidic.main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/mobile-dictionary.iml" filepath="$PROJECT_DIR$/.idea/mobile-dictionary.iml" />
     </modules>
   </component>
 </project>

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/WordDetailDto.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/WordDetailDto.java
@@ -1,7 +1,9 @@
 package com.kimtaeyang.mobidic.dto;
 
+
 import com.kimtaeyang.mobidic.entity.Def;
 import com.kimtaeyang.mobidic.entity.Word;
+import com.kimtaeyang.mobidic.type.Difficulty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,16 +19,20 @@ import java.util.UUID;
 @Builder
 public class WordDetailDto {
     private UUID id;
+    private UUID vocabId;
     private String expression;
+    private Difficulty difficulty;
     private Timestamp createdAt;
     private List<Def> defs;
 
-    public static WordDetailDto fromEntity(Word word, List<Def> definitions) {
+    public static WordDetailDto fromEntity (Word word, List<Def> defs, Difficulty difficulty) {
         return WordDetailDto.builder()
                 .id(word.getId())
+                .vocabId(word.getVocab().getId())
                 .expression(word.getExpression())
+                .difficulty(difficulty)
                 .createdAt(word.getCreatedAt())
-                .defs(definitions)
+                .defs(defs)
                 .build();
     }
 }

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/WordDto.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/WordDto.java
@@ -1,7 +1,6 @@
 package com.kimtaeyang.mobidic.dto;
 
 import com.kimtaeyang.mobidic.entity.Word;
-import com.kimtaeyang.mobidic.type.Difficulty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -16,15 +15,15 @@ import java.util.UUID;
 @Builder
 public class WordDto {
     private UUID id;
+    private UUID vocabId;
     private String expression;
-    private Difficulty difficulty;
     private Timestamp createdAt;
 
-    public static WordDto fromEntity (Word word, Difficulty difficulty) {
+    public static WordDto fromEntity (Word word) {
         return WordDto.builder()
                 .id(word.getId())
+                .vocabId(word.getVocab().getId())
                 .expression(word.getExpression())
-                .difficulty(difficulty)
                 .createdAt(word.getCreatedAt())
                 .build();
     }

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/repository/RateRepository.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/repository/RateRepository.java
@@ -1,6 +1,7 @@
 package com.kimtaeyang.mobidic.repository;
 
 import com.kimtaeyang.mobidic.entity.Rate;
+import com.kimtaeyang.mobidic.entity.Word;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,11 +10,11 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface RateRepository extends JpaRepository<Rate, UUID> {
-    Optional<Rate> getRateByWordId(UUID wordId);
-
     @Query("select (1.0*sum(r.isLearned)) / count(w)"+
             " from Word w join Rate r"+
             " on w = r.word"+
             " where w.vocab.id = :vocabId")
     Optional<Double> getVocabLearningRate(@Param("vocab") UUID vocabId);
+
+    Optional<Rate> getRateByWord(Word word);
 }

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/MemberService.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/MemberService.java
@@ -52,7 +52,7 @@ public class MemberService {
                         .ifPresent((m) -> { throw new ApiException(DUPLICATED_NICKNAME); });
 
         member.setNickname(request.getNickname());
-        memberRepository.save(member);
+        member = memberRepository.save(member);
 
         return UpdateNicknameDto.Response.builder()
                 .nickname(member.getNickname())

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/RateService.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/RateService.java
@@ -2,9 +2,10 @@ package com.kimtaeyang.mobidic.service;
 
 import com.kimtaeyang.mobidic.dto.RateDto;
 import com.kimtaeyang.mobidic.entity.Rate;
+import com.kimtaeyang.mobidic.entity.Word;
 import com.kimtaeyang.mobidic.exception.ApiException;
 import com.kimtaeyang.mobidic.repository.RateRepository;
-import com.kimtaeyang.mobidic.repository.VocabRepository;
+import com.kimtaeyang.mobidic.repository.WordRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -13,19 +14,21 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
-import static com.kimtaeyang.mobidic.code.GeneralResponseCode.INTERNAL_SERVER_ERROR;
-import static com.kimtaeyang.mobidic.code.GeneralResponseCode.NO_RATE;
+import static com.kimtaeyang.mobidic.code.GeneralResponseCode.*;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class RateService {
+    private final WordRepository wordRepository;
     private final RateRepository rateRepository;
 
     @Transactional(readOnly = true)
     @PreAuthorize("@rateAccessHandler.ownershipCheck(#wordId)")
     public RateDto getRateByWordId(UUID wordId) {
-        Rate rate = rateRepository.getRateByWordId(wordId)
+        Word word = wordRepository.findById(wordId)
+                .orElseThrow(() -> new ApiException(NO_WORD));
+        Rate rate = rateRepository.getRateByWord(word)
                 .orElseThrow(() -> new ApiException(NO_RATE));
 
         return RateDto.fromEntity(rate);
@@ -41,7 +44,9 @@ public class RateService {
     @Transactional
     @PreAuthorize("@wordAccessHandler.ownershipCheck(#wordId)")
     public void toggleRateByWordId(UUID wordId) {
-        Rate rate = rateRepository.getRateByWordId(wordId)
+        Word word = wordRepository.findById(wordId)
+                .orElseThrow(() -> new ApiException(NO_WORD));
+        Rate rate = rateRepository.getRateByWord(word)
                 .orElseThrow(() -> new ApiException(NO_RATE));
 
         if(rate.getIsLearned() > 0){

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/VocabService.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/VocabService.java
@@ -36,6 +36,8 @@ public class VocabService {
             UUID memberId,
             AddVocabDto.@Valid Request request
     ) {
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApiException(NO_MEMBER));
         vocabRepository.findByTitle(request.getTitle())
                 .ifPresent((v) -> { throw new ApiException(DUPLICATED_TITLE); });
 

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/VocabService.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/VocabService.java
@@ -36,7 +36,7 @@ public class VocabService {
             UUID memberId,
             AddVocabDto.@Valid Request request
     ) {
-        memberRepository.findById(memberId)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ApiException(NO_MEMBER));
         vocabRepository.findByTitle(request.getTitle())
                 .ifPresent((v) -> { throw new ApiException(DUPLICATED_TITLE); });
@@ -44,9 +44,7 @@ public class VocabService {
         Vocab vocab = Vocab.builder()
                 .title(request.getTitle())
                 .description(request.getDescription())
-                .member(Member.builder()
-                        .id(memberId)
-                        .build())
+                .member(member)
                 .build();
         vocab = vocabRepository.save(vocab);
 

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/VocabService.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/VocabService.java
@@ -6,6 +6,7 @@ import com.kimtaeyang.mobidic.dto.VocabDto;
 import com.kimtaeyang.mobidic.entity.Member;
 import com.kimtaeyang.mobidic.entity.Vocab;
 import com.kimtaeyang.mobidic.exception.ApiException;
+import com.kimtaeyang.mobidic.repository.MemberRepository;
 import com.kimtaeyang.mobidic.repository.VocabRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static com.kimtaeyang.mobidic.code.AuthResponseCode.NO_MEMBER;
 import static com.kimtaeyang.mobidic.code.GeneralResponseCode.DUPLICATED_TITLE;
 import static com.kimtaeyang.mobidic.code.GeneralResponseCode.NO_VOCAB;
 
@@ -26,6 +28,7 @@ import static com.kimtaeyang.mobidic.code.GeneralResponseCode.NO_VOCAB;
 @RequiredArgsConstructor
 public class VocabService {
     private final VocabRepository vocabRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     @PreAuthorize("@memberAccessHandler.ownershipCheck(#memberId)")
@@ -51,7 +54,10 @@ public class VocabService {
     @Transactional(readOnly = true)
     @PreAuthorize("@memberAccessHandler.ownershipCheck(#memberId)")
     public List<VocabDto> getVocabsByMemberId(UUID memberId) {
-        return vocabRepository.findByMember(Member.builder().id(memberId).build())
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApiException(NO_MEMBER));
+
+        return vocabRepository.findByMember(member)
                 .stream().map(VocabDto::fromEntity).collect(Collectors.toList());
     }
 

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/service/MemberServiceTest.java
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/service/MemberServiceTest.java
@@ -1,0 +1,175 @@
+package com.kimtaeyang.mobidic.service;
+
+import com.kimtaeyang.mobidic.dto.MemberDto;
+import com.kimtaeyang.mobidic.dto.UpdateNicknameDto;
+import com.kimtaeyang.mobidic.dto.UpdatePasswordDto;
+import com.kimtaeyang.mobidic.entity.Member;
+import com.kimtaeyang.mobidic.repository.MemberRepository;
+import com.kimtaeyang.mobidic.security.JwtBlacklistService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@TestPropertySource(properties = {
+        "jwt.secret=qwerqwerqwerqwerqwerqwerqwerqwer",
+        "jwt.exp=3600"
+})
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {MemberService.class, MemberServiceTest.TestConfig.class})
+class MemberServiceTest {
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private static final String UID = "9f81b0d7-2f8e-4ad3-ae18-41c73dc71b39";
+
+    @Test
+    @DisplayName("[MemberService] Get member detail success")
+    @WithMockUser(username = UID)
+    void getMemberDetailByIdSuccess() {
+        Member member = Member.builder()
+                .id(UUID.fromString(UID))
+                .email("test@test.com")
+                .nickname("test")
+                .password(passwordEncoder.encode("test"))
+                .build();
+
+        //given
+        given(memberRepository.findById(any(UUID.class)))
+                .willReturn(Optional.of(member));
+
+        //when
+        MemberDto response = memberService.getMemberDetailById(UUID.fromString(UID));
+
+        //then
+        assertEquals(member.getNickname(), response.getNickname());
+        assertEquals(member.getEmail(), response.getEmail());
+        assertEquals(UUID.fromString(UID), response.getId());
+    }
+
+    @Test
+    @DisplayName("[MemberService] Update member nickname success")
+    @WithMockUser(username = UID)
+    void updateMemberNicknameSuccess() {
+        Member defaultMember = Member.builder()
+                .id(UUID.fromString(UID))
+                .email("test@test.com")
+                .nickname("test")
+                .password(passwordEncoder.encode("testTest1"))
+                .build();
+
+        UpdateNicknameDto.Request request = UpdateNicknameDto.Request.builder()
+                .nickname("test2")
+                .build();
+
+        ArgumentCaptor<Member> memberCaptor =
+                ArgumentCaptor.forClass(Member.class);
+
+        //given
+        given(memberRepository.findById(any(UUID.class)))
+                .willReturn(Optional.of(defaultMember));
+        given(memberRepository.findByNickname(anyString()))
+                .willReturn(Optional.empty());
+        given(memberRepository.save(any(Member.class)))
+                .willAnswer(invocation -> {
+                    Member memberArg = invocation.getArgument(0);
+                    memberArg.setNickname(request.getNickname());
+                    return memberArg;
+                });
+
+        //when
+        UpdateNicknameDto.Response response = memberService.updateMemberNickname(UUID.fromString(UID), request);
+
+        //then
+        verify(memberRepository, times(1))
+                .save(memberCaptor.capture());
+
+        assertEquals(request.getNickname(), response.getNickname());
+        assertEquals(UUID.fromString(UID), response.getId());
+    }
+
+    @Test
+    @DisplayName("[MemberService] Update member password success")
+    @WithMockUser(username = UID)
+    void updateMemberPasswordSuccess() {
+        Member defaultMember = Member.builder()
+                .id(UUID.fromString(UID))
+                .email("test@test.com")
+                .nickname("test")
+                .password(passwordEncoder.encode("testTest1"))
+                .build();
+
+        UpdatePasswordDto.Request request = UpdatePasswordDto.Request.builder()
+                .password("testTest2")
+                .build();
+
+        ArgumentCaptor<Member> memberCaptor =
+                ArgumentCaptor.forClass(Member.class);
+
+        //given
+        given(memberRepository.findById(any(UUID.class)))
+                .willReturn(Optional.of(defaultMember));
+        given(memberRepository.save(any(Member.class)))
+                .willAnswer(invocation -> {
+                    Member memberArg = invocation.getArgument(0);
+                    memberArg.setPassword(passwordEncoder.encode(
+                                    request.getPassword()));
+                    return memberArg;
+                });
+
+        //when
+        memberService.updateMemberPassword(UUID.fromString(UID), request);
+
+        //then
+        verify(memberRepository, times(1))
+                .save(memberCaptor.capture());
+        Member savedMember = memberCaptor.getValue();
+
+        assertThat(passwordEncoder.matches(request.getPassword(), savedMember.getPassword()));
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        public MemberRepository memberRepository() {
+            return Mockito.mock(MemberRepository.class);
+        }
+
+        @Bean
+        public JwtBlacklistService jwtBlacklistService() {
+            return Mockito.mock(JwtBlacklistService.class);
+        }
+
+        @Bean
+        public PasswordEncoder passwordEncoder() {
+            return new BCryptPasswordEncoder();
+        }
+    }
+}

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/service/VocabServiceTest.java
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/service/VocabServiceTest.java
@@ -1,0 +1,201 @@
+package com.kimtaeyang.mobidic.service;
+
+import com.kimtaeyang.mobidic.dto.AddVocabDto;
+import com.kimtaeyang.mobidic.dto.UpdateVocabDto;
+import com.kimtaeyang.mobidic.dto.VocabDto;
+import com.kimtaeyang.mobidic.entity.Member;
+import com.kimtaeyang.mobidic.entity.Vocab;
+import com.kimtaeyang.mobidic.repository.MemberRepository;
+import com.kimtaeyang.mobidic.repository.VocabRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {VocabService.class, VocabServiceTest.TestConfig.class})
+class VocabServiceTest {
+    @Autowired
+    private VocabRepository vocabRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private VocabService vocabService;
+
+    @Test
+    @DisplayName("[VocabService] Add vocab success")
+    void addVocabSuccess() {
+        resetMock();
+
+        UUID vocabId = UUID.randomUUID();
+
+        AddVocabDto.Request request = AddVocabDto.Request.builder()
+                .title("title")
+                .description("description")
+                .build();
+        ArgumentCaptor<Vocab> captor =
+                ArgumentCaptor.forClass(Vocab.class);
+
+        //given
+        given(memberRepository.findById(any(UUID.class)))
+                .willReturn(Optional.of(Mockito.mock(Member.class)));
+        given(vocabRepository.findByTitle(anyString()))
+                .willReturn(Optional.empty());
+        given(vocabRepository.save(any(Vocab.class)))
+                .willAnswer(invocation -> {
+                    Vocab vocabArg = invocation.getArgument(0);
+                    vocabArg.setId(vocabId);
+                    return vocabArg;
+                });
+
+        //when
+        AddVocabDto.Response response = vocabService.addVocab(UUID.randomUUID(), request);
+
+        //then
+        verify(vocabRepository, times(1))
+                .save(captor.capture());
+
+        assertEquals(request.getTitle(), response.getTitle());
+        assertEquals(request.getDescription(), response.getDescription());
+        assertEquals(vocabId, response.getId());
+    }
+
+    @Test
+    @DisplayName("[VocabService] Get vocabs by member id success")
+    void getVocabsByMemberIdSuccess() {
+        resetMock();
+
+        Vocab defaultVocab = Vocab.builder()
+                .member(Mockito.mock(Member.class))
+                .title("title")
+                .description("description")
+                .build();
+
+        ArrayList<Vocab> vocabs = new ArrayList<>();
+        vocabs.add(defaultVocab);
+
+        //given
+        given(memberRepository.findById(any(UUID.class)))
+                .willReturn(Optional.of(Mockito.mock(Member.class)));
+        given(vocabRepository.findByMember(any(Member.class)))
+                .willReturn(vocabs);
+
+        //when
+        List<VocabDto> response = vocabService.getVocabsByMemberId(UUID.randomUUID());
+
+        //then
+        assertEquals(vocabs.getFirst().getMember().getId(), response.getFirst().getMemberId());
+        assertEquals(vocabs.getFirst().getTitle(), response.getFirst().getTitle());
+        assertEquals(vocabs.getFirst().getDescription(), response.getFirst().getDescription());
+    }
+
+    @Test
+    @DisplayName("[VocabService] Get vocab by vocab id success")
+    void getVocabByVocabIdSuccess() {
+        resetMock();
+
+        UUID vocabId = UUID.randomUUID();
+
+        Vocab defaultVocab = Vocab.builder()
+                .id(vocabId)
+                .member(Mockito.mock(Member.class))
+                .title("title")
+                .description("description")
+                .build();
+
+        //given
+        given(vocabRepository.findById(any(UUID.class)))
+                .willReturn(Optional.of(defaultVocab));
+
+        //when
+        VocabDto response = vocabService.getVocabById(vocabId);
+
+        //then
+        assertEquals(vocabId, response.getId());
+        assertEquals(defaultVocab.getTitle(), response.getTitle());
+        assertEquals(defaultVocab.getDescription(), response.getDescription());
+    }
+
+    @Test
+    @DisplayName("[VocabService] Update vocab success")
+    void updateVocabSuccess() {
+        resetMock();
+
+        UUID vocabId = UUID.randomUUID();
+
+        Vocab defaultVocab = Vocab.builder()
+                .id(vocabId)
+                .member(Mockito.mock(Member.class))
+                .title("title")
+                .description("description")
+                .build();
+
+        UpdateVocabDto.Request request =
+                UpdateVocabDto.Request.builder()
+                        .title("title2")
+                        .description("description2")
+                        .build();
+
+        ArgumentCaptor<Vocab> captor =
+                ArgumentCaptor.forClass(Vocab.class);
+
+        //given
+        given(vocabRepository.findById(any(UUID.class)))
+                .willReturn(Optional.of(defaultVocab));
+        given(vocabRepository.findByTitle(anyString()))
+                .willReturn(Optional.empty());
+        given(vocabRepository.save(any(Vocab.class)))
+                .willAnswer(invocation -> {
+                   Vocab vocabArg = invocation.getArgument(0);
+                   vocabArg.setTitle(request.getTitle());
+                   vocabArg.setDescription(request.getDescription());
+                   return vocabArg;
+                });
+
+        //when
+        UpdateVocabDto.Response response =
+                vocabService.updateVocab(vocabId, request);
+
+        //then
+        verify(vocabRepository, times(1))
+                .save(captor.capture());
+        assertEquals(vocabId, response.getId());
+        assertEquals(request.getTitle(), response.getTitle());
+        assertEquals(request.getDescription(), response.getDescription());
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        public VocabRepository vocabRepository() {
+            return Mockito.mock(VocabRepository.class);
+        }
+
+        @Bean
+        public MemberRepository memberRepository() {
+            return Mockito.mock(MemberRepository.class);
+        }
+    }
+
+    private void resetMock(){
+        Mockito.reset(vocabRepository, memberRepository);
+    }
+}

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/service/WordServiceTest.java
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/service/WordServiceTest.java
@@ -1,0 +1,237 @@
+package com.kimtaeyang.mobidic.service;
+
+import com.kimtaeyang.mobidic.dto.AddWordDto;
+import com.kimtaeyang.mobidic.dto.WordDetailDto;
+import com.kimtaeyang.mobidic.entity.Def;
+import com.kimtaeyang.mobidic.entity.Rate;
+import com.kimtaeyang.mobidic.entity.Vocab;
+import com.kimtaeyang.mobidic.entity.Word;
+import com.kimtaeyang.mobidic.repository.DefRepository;
+import com.kimtaeyang.mobidic.repository.RateRepository;
+import com.kimtaeyang.mobidic.repository.VocabRepository;
+import com.kimtaeyang.mobidic.repository.WordRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {WordService.class, WordServiceTest.TestConfig.class})
+class WordServiceTest {
+    @Autowired
+    private WordRepository wordRepository;
+    @Autowired
+    private VocabRepository vocabRepository;
+
+    @Autowired
+    private DefRepository defRepository;
+
+    @Autowired
+    private RateRepository rateRepository;
+
+    @Autowired
+    private WordService wordService;
+
+    @Test
+    @DisplayName("[WordService] Add vocab success")
+    void addWordSuccess() {
+        resetMock();
+
+        UUID wordId = UUID.randomUUID();
+
+        AddWordDto.Request request = AddWordDto.Request.builder()
+                .expression("test")
+                .build();
+        
+        ArgumentCaptor<Word> captor =
+                ArgumentCaptor.forClass(Word.class);
+
+        //given
+        given(vocabRepository.findById(any(UUID.class)))
+                .willReturn(Optional.of(Mockito.mock(Vocab.class)));
+        given(wordRepository.findByExpression(anyString()))
+                .willReturn(Optional.empty());
+        given(wordRepository.save(any(Word.class)))
+                .willAnswer(invocation -> {
+                    Word wordArg = invocation.getArgument(0);
+                    wordArg.setId(wordId);
+                    return wordArg;
+                });
+
+        //when
+        AddWordDto.Response response = wordService.addWord(UUID.randomUUID(), request);
+
+        //then
+        verify(wordRepository, times(1))
+                .save(captor.capture());
+
+        assertEquals(request.getExpression(), response.getExpression());
+        assertEquals(wordId, response.getId());
+    }
+
+    @Test
+    @DisplayName("[WordService] Get words by vocab id success")
+    void getWordsByVocabIdSuccess() {
+        resetMock();
+
+        Word defaultWord = Word.builder()
+                .vocab(Mockito.mock(Vocab.class))
+                .expression("expression")
+                .build();
+
+        Rate defaultRate = Rate.builder()
+                .word(defaultWord)
+                .isLearned(0)
+                .incorrectCount(4)
+                .correctCount(3)
+                .build();
+
+        ArrayList<Word> words = new ArrayList<>();
+        words.add(defaultWord);
+
+        //given
+        given(vocabRepository.findById(any(UUID.class)))
+                .willReturn(Optional.of(Mockito.mock(Vocab.class)));
+        given(wordRepository.findByVocab(any(Vocab.class)))
+                .willReturn(words);
+        given(rateRepository.getRateByWord(any(Word.class)))
+                .willReturn(Optional.of(defaultRate));
+
+        //when
+        List<WordDetailDto> response = wordService.getWordsByVocabId(UUID.randomUUID());
+
+        //then
+        assertEquals(words.getFirst().getVocab().getId(), response.getFirst().getVocabId());
+        assertEquals(words.getFirst().getExpression(), response.getFirst().getExpression());
+    }
+
+    @Test
+    @DisplayName("[WordService] Get word detail success")
+    void getWordDetailSuccess() {
+        resetMock();
+
+        UUID vocabId = UUID.randomUUID();
+
+        Word defaultWord = Word.builder()
+                .id(vocabId)
+                .vocab(Mockito.mock(Vocab.class))
+                .expression("expression")
+                .build();
+
+        Rate defaultRate = Rate.builder()
+                .word(defaultWord)
+                .isLearned(0)
+                .incorrectCount(4)
+                .correctCount(3)
+                .build();
+
+        Def defaultDef = Mockito.mock(Def.class);
+
+        ArrayList<Def> defs = new ArrayList<>();
+        defs.add(defaultDef);
+
+        //given
+        given(wordRepository.findById(any(UUID.class)))
+                .willReturn(Optional.of(defaultWord));
+        given(rateRepository.getRateByWord(any(Word.class)))
+                .willReturn(Optional.of(defaultRate));
+        given(defRepository.findByWord(any(Word.class)))
+                .willReturn(defs);
+
+        //when
+        WordDetailDto response =
+                wordService.getWordDetail(UUID.randomUUID());
+
+        //then
+        assertEquals(vocabId, response.getId());
+        assertEquals(defaultWord.getExpression(), response.getExpression());
+        assertEquals(defs, response.getDefs());
+    }
+
+    @Test
+    @DisplayName("[WordService] Update word success")
+    void updateWordSuccess() {
+        resetMock();
+
+        UUID wordId = UUID.randomUUID();
+
+        Word defaultWord = Word.builder()
+                .id(wordId)
+                .vocab(Mockito.mock(Vocab.class))
+                .expression("expression")
+                .build();
+
+        AddWordDto.Request request =
+                AddWordDto.Request.builder()
+                        .expression("expression2")
+                        .build();
+
+        ArgumentCaptor<Word> captor =
+                ArgumentCaptor.forClass(Word.class);
+
+        //given
+        given(wordRepository.findById(any(UUID.class)))
+                .willReturn(Optional.of(defaultWord));
+        given(vocabRepository.findByTitle(anyString()))
+                .willReturn(Optional.empty());
+        given(wordRepository.save(any(Word.class)))
+                .willAnswer(invocation -> {
+                   Word wordArg = invocation.getArgument(0);
+                   wordArg.setExpression(request.getExpression());
+                   return wordArg;
+                });
+
+        //when
+        AddWordDto.Response response =
+                wordService.updateWord(wordId, request);
+
+        //then
+        verify(wordRepository, times(1))
+                .save(captor.capture());
+        assertEquals(wordId, response.getId());
+        assertEquals(request.getExpression(), response.getExpression());
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        public WordRepository wordRepository() {
+            return Mockito.mock(WordRepository.class);
+        }
+
+        @Bean
+        public VocabRepository vocabRepository() {
+            return Mockito.mock(VocabRepository.class);
+        }
+
+        @Bean
+        public DefRepository defRepository() {
+            return Mockito.mock(DefRepository.class);
+        }
+
+        @Bean
+        public RateRepository rateRepository() {
+            return Mockito.mock(RateRepository.class);
+        }
+    }
+
+    private void resetMock(){
+        Mockito.reset(wordRepository, vocabRepository, defRepository, rateRepository);
+    }
+}


### PR DESCRIPTION
[fix: 단어장 조회 시 Member validation 추가]
- request의 memberId가 유효한지 DB 조회를 통해 검증

[refactor: 객체 DB에 save 후 반환 값 재사용]
- 단순 코드 수정

[fix: 단어장 추가 시 Member validation 추가]
- request의 memberId가 유효한지 DB 조회를 통해 검증


[fix: 단어 DTO 구조 변경]
- WordDetailDto는 표현, 뜻, 난이도 모두 포함

[fix: Rate find 로직 변경]
- Raw query에서 ORM 방식으로 변경

[test: Service Unit Test]
- MemberService, VocabService, WordService 메서드 성공 케이스 유닛 테스트 진행