### PR TITLE
Auth, Member, Vocab 통합 테스트 [김태현]

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$/mobidic_spring" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/mobile-dictionary.iml
+++ b/.idea/mobile-dictionary.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/code/GeneralResponseCode.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/code/GeneralResponseCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum GeneralResponseCode implements ApiResponseCode {
     OK(HttpStatus.OK, "OK"),
     NOT_FOUND(HttpStatus.NOT_FOUND, "Not found"),
-    INVALID_REQUEST(HttpStatus.NOT_FOUND, "Invalid Request"),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "Invalid Request"),
     NO_VOCAB(HttpStatus.NOT_FOUND, "No vocab found"),
     NO_WORD(HttpStatus.NOT_FOUND, "No word found"),
     NO_DEF(HttpStatus.NOT_FOUND, "No def found"),
@@ -19,7 +19,7 @@ public enum GeneralResponseCode implements ApiResponseCode {
     DUPLICATED_WORD(HttpStatus.CONFLICT, "Word is duplicated"),
     DUPLICATED_DEFINITION(HttpStatus.CONFLICT, "Definition is duplicated"),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "Method is not supported"),
-    INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "Invalid request Body"),
+    INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "Invalid request body"),
     FORBIDDEN(HttpStatus.FORBIDDEN, "Forbidden request"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error");
 

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/controller/MemberController.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/controller/MemberController.java
@@ -48,7 +48,7 @@ public class MemberController {
         String token = httpServletRequest.getHeader("Authorization").substring(7);
 
         return ApiResponse.toResponseEntity(OK,
-                memberService.updateMemberPassword(UUID.fromString(memberId), request, UUID.fromString(token)));
+                memberService.updateMemberPassword(UUID.fromString(memberId), request, token));
     }
 
     @PatchMapping("/withdraw/{memberId}")

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/controller/MemberController.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/controller/MemberController.java
@@ -42,10 +42,13 @@ public class MemberController {
     @PatchMapping("/pschn/{memberId}")
     public ResponseEntity<?> updateMemberPassword(
             @PathVariable String memberId,
-            @RequestBody @Valid UpdatePasswordDto.Request request
+            @RequestBody @Valid UpdatePasswordDto.Request request,
+            HttpServletRequest httpServletRequest
     ){
+        String token = httpServletRequest.getHeader("Authorization").substring(7);
+
         return ApiResponse.toResponseEntity(OK,
-                memberService.updateMemberPassword(UUID.fromString(memberId), request));
+                memberService.updateMemberPassword(UUID.fromString(memberId), request, UUID.fromString(token)));
     }
 
     @PatchMapping("/withdraw/{memberId}")

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/controller/VocabController.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/controller/VocabController.java
@@ -49,7 +49,7 @@ public class VocabController {
     @PatchMapping("/{vocabId}")
     public ResponseEntity<?> updateVocab(
             @PathVariable String vocabId,
-            @RequestBody UpdateVocabDto.Request request
+            @RequestBody @Valid UpdateVocabDto.Request request
     ) {
         return ApiResponse.toResponseEntity(OK,
                 vocabService.updateVocab(UUID.fromString(vocabId), request));

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/AddVocabDto.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/AddVocabDto.java
@@ -17,9 +17,9 @@ public class AddVocabDto {
     @Builder
     public static class Request {
         @NotBlank
-        @Size(min = 1, max = 32)
+        @Size(min = 1, max = 32, message = "Invalid title pattern")
         private String title;
-        @Size(max = 64)
+        @Size(max = 64, message = "Invalid description pattern")
         private String description;
     }
 

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/JoinDto.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/JoinDto.java
@@ -1,10 +1,8 @@
 package com.kimtaeyang.mobidic.dto;
 
 import com.kimtaeyang.mobidic.entity.Member;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -19,16 +17,15 @@ public class JoinDto {
     @Builder
     public static class Request{
         @NotBlank
-        @Size(min = 2, max = 100)
-        @Email
+        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,100}$", message = "Invalid email pattern")
         private String email;
 
         @NotBlank
-        @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9-_]{2,16}$")
+        @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9-_]{2,16}$", message = "Invalid nickname pattern")
         private String nickname;
 
         @NotBlank
-        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,128}$")
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,128}$", message = "Invalid password pattern")
         //최소 8자, 숫자와 알파벳
         private String password;
     }

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/LoginDto.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/LoginDto.java
@@ -7,11 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import static com.kimtaeyang.mobidic.code.GeneralResponseCode.BAD_REQUEST;
-
 public class LoginDto {
-    private static final String EMAIL_ERROR_MESSAGE = BAD_REQUEST.getMessage();
-
     @Data
     @AllArgsConstructor
     @NoArgsConstructor

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/LoginDto.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/LoginDto.java
@@ -1,18 +1,24 @@
 package com.kimtaeyang.mobidic.dto;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import static com.kimtaeyang.mobidic.code.GeneralResponseCode.BAD_REQUEST;
+
 public class LoginDto {
+    private static final String EMAIL_ERROR_MESSAGE = BAD_REQUEST.getMessage();
+
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
     public static class Request{
         @NotBlank
+        @Email(message = "Invalid email pattern")
         private String email;
         @NotBlank
         private String password;

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/UpdateNicknameDto.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/UpdateNicknameDto.java
@@ -16,7 +16,7 @@ public class UpdateNicknameDto {
     @Builder
     public static class Request {
         @NotBlank
-        @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9-_]{2,16}$")
+        @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9-_]{2,16}$", message = "Invalid nickname pattern")
         private String nickname;
     }
 

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/UpdatePasswordDto.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/UpdatePasswordDto.java
@@ -16,7 +16,7 @@ public class UpdatePasswordDto {
     @Builder
     public static class Request {
         @NotBlank
-        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,128}$")
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,128}$", message = "Invalid password pattern")
         //최소 8자, 숫자와 알파벳
         private String password;
     }

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/UpdateVocabDto.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/dto/UpdateVocabDto.java
@@ -17,9 +17,9 @@ public class UpdateVocabDto {
     @Builder
     public static class Request {
         @NotBlank
-        @Size(min = 1, max = 32)
+        @Size(min = 1, max = 32, message = "Invalid title pattern")
         private String title;
-        @Size(max = 64)
+        @Size(max = 64, message = "Invalid description pattern")
         private String description;
     }
     @Data

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/exception/AuthAccessDeniedHandler.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/exception/AuthAccessDeniedHandler.java
@@ -1,7 +1,7 @@
 package com.kimtaeyang.mobidic.exception;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.kimtaeyang.mobidic.dto.ApiResponse;
+import com.kimtaeyang.mobidic.dto.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -29,15 +29,16 @@ public class AuthAccessDeniedHandler implements AccessDeniedHandler {
         log.error("errorCode : {}, uri : {}, message : {}",
                 accessDeniedException, request.getRequestURI(), accessDeniedException   .getMessage());
 
-        ApiResponse<?> apiResponse = ApiResponse.builder()
-                .data(null)
+        ErrorResponse<?> errorResponse = ErrorResponse.builder()
+                .errors(null)
                 .status(FORBIDDEN.getStatus().value())
                 .message(FORBIDDEN.getMessage())
                 .build();
-        String responseBody = objectMapper.writeValueAsString(apiResponse);
+
+        String responseBody = objectMapper.writeValueAsString(errorResponse);
 
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setStatus(FORBIDDEN.getStatus().value());
+        response.setStatus(errorResponse.getStatus());
         response.setCharacterEncoding("UTF-8");
         response.getWriter().write(responseBody);
     }

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/exception/AuthAuthenticationEntryPoint.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/exception/AuthAuthenticationEntryPoint.java
@@ -1,7 +1,6 @@
 package com.kimtaeyang.mobidic.exception;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.kimtaeyang.mobidic.dto.ApiResponse;
 import com.kimtaeyang.mobidic.dto.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/exception/AuthAuthenticationEntryPoint.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/exception/AuthAuthenticationEntryPoint.java
@@ -2,6 +2,7 @@ package com.kimtaeyang.mobidic.exception;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kimtaeyang.mobidic.dto.ApiResponse;
+import com.kimtaeyang.mobidic.dto.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -29,16 +30,16 @@ public class AuthAuthenticationEntryPoint implements AuthenticationEntryPoint {
         log.error("errorCode : {}, uri : {}, message : {}",
                 authException, request.getRequestURI(), authException.getMessage());
 
-        ApiResponse<?> apiResponse = ApiResponse.builder()
-                .data(null)
+        ErrorResponse<?> errorResponse = ErrorResponse.builder()
+                .errors(null)
                 .status(UNAUTHORIZED.getStatus().value())
                 .message(UNAUTHORIZED.getMessage())
                 .build();
 
-        String responseBody = objectMapper.writeValueAsString(apiResponse);
+        String responseBody = objectMapper.writeValueAsString(errorResponse);
 
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setStatus(UNAUTHORIZED.getStatus().value());
+        response.setStatus(errorResponse.getStatus());
         response.setCharacterEncoding("UTF-8");
         response.getWriter().write(responseBody);
     }

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/MemberService.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/MemberService.java
@@ -64,7 +64,7 @@ public class MemberService {
     @Transactional
     @PreAuthorize("@memberAccessHandler.ownershipCheck(#memberId)")
     public UpdatePasswordDto.Response updateMemberPassword(
-            UUID memberId, UpdatePasswordDto.Request request, UUID token
+            UUID memberId, UpdatePasswordDto.Request request, String token
     ) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ApiException(NO_MEMBER));

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/MemberService.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/MemberService.java
@@ -72,7 +72,7 @@ public class MemberService {
         member.setPassword(passwordEncoder.encode(request.getPassword()));
         memberRepository.save(member);
 
-        authService.logout(memberId, token.toString());
+        authService.logout(memberId, token);
 
         return UpdatePasswordDto.Response.builder()
                 .id(member.getId())

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/MemberService.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/MemberService.java
@@ -30,6 +30,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtBlacklistService jwtBlacklistService;
+    private final AuthService authService;
 
     @Transactional(readOnly = true)
     @PreAuthorize("@memberAccessHandler.ownershipCheck(#memberId)")
@@ -63,13 +64,15 @@ public class MemberService {
     @Transactional
     @PreAuthorize("@memberAccessHandler.ownershipCheck(#memberId)")
     public UpdatePasswordDto.Response updateMemberPassword(
-            UUID memberId, UpdatePasswordDto.Request request
+            UUID memberId, UpdatePasswordDto.Request request, UUID token
     ) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ApiException(NO_MEMBER));
 
         member.setPassword(passwordEncoder.encode(request.getPassword()));
         memberRepository.save(member);
+
+        authService.logout(memberId, token.toString());
 
         return UpdatePasswordDto.Response.builder()
                 .id(member.getId())

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/VocabService.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/VocabService.java
@@ -34,7 +34,7 @@ public class VocabService {
     @PreAuthorize("@memberAccessHandler.ownershipCheck(#memberId)")
     public AddVocabDto.Response addVocab(
             UUID memberId,
-            AddVocabDto.@Valid Request request
+            @Valid AddVocabDto.Request request
     ) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ApiException(NO_MEMBER));
@@ -72,7 +72,10 @@ public class VocabService {
 
     @Transactional
     @PreAuthorize("@vocabAccessHandler.ownershipCheck(#vocabId)")
-    public UpdateVocabDto.Response updateVocab(UUID vocabId, UpdateVocabDto.Request request) {
+    public UpdateVocabDto.Response updateVocab(
+            UUID vocabId,
+            @Valid UpdateVocabDto.Request request
+    ) {
         Vocab vocab = vocabRepository.findById(vocabId)
                 .orElseThrow(() -> new ApiException(NO_VOCAB));
 

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/VocabService.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/VocabService.java
@@ -76,9 +76,6 @@ public class VocabService {
         Vocab vocab = vocabRepository.findById(vocabId)
                 .orElseThrow(() -> new ApiException(NO_VOCAB));
 
-        vocabRepository.findByTitle(request.getTitle())
-                .ifPresent((v) -> { throw new ApiException(DUPLICATED_TITLE); });
-
         vocab.setTitle(request.getTitle());
         vocab.setDescription(request.getDescription());
         vocab = vocabRepository.save(vocab);

--- a/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/VocabService.java
+++ b/mobidic_spring/src/main/java/com/kimtaeyang/mobidic/service/VocabService.java
@@ -73,9 +73,7 @@ public class VocabService {
     @Transactional
     @PreAuthorize("@vocabAccessHandler.ownershipCheck(#vocabId)")
     public UpdateVocabDto.Response updateVocab(
-            UUID vocabId,
-            @Valid UpdateVocabDto.Request request
-    ) {
+            UUID vocabId, UpdateVocabDto.Request request) {
         Vocab vocab = vocabRepository.findById(vocabId)
                 .orElseThrow(() -> new ApiException(NO_VOCAB));
 

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/integration/AuthIntegrationTest.java
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/integration/AuthIntegrationTest.java
@@ -64,9 +64,9 @@ public class AuthIntegrationTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.email")
-                                .value("test@test.com"))
+                        .value("test@test.com"))
                 .andExpect(jsonPath("$.data.nickname")
-                                .value("test"));
+                        .value("test"));
 
         request.setEmail("test@test");
         request.setNickname("1");
@@ -83,9 +83,9 @@ public class AuthIntegrationTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message")
-                                .value(INVALID_REQUEST_BODY.getMessage()))
+                        .value(INVALID_REQUEST_BODY.getMessage()))
                 .andExpect(jsonPath("$.errors")
-                                .value(expectedErrors));
+                        .value(expectedErrors));
     }
 
     @DisplayName("[Auth][Integration] Login test")
@@ -128,7 +128,7 @@ public class AuthIntegrationTest {
                         .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.message")
-                                .value(LOGIN_FAILED.getMessage()));
+                        .value(LOGIN_FAILED.getMessage()));
 
         //Login fail invalid email
         loginRequest.setEmail("wrong@email.com");
@@ -137,7 +137,7 @@ public class AuthIntegrationTest {
                         .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.message")
-                                .value(LOGIN_FAILED.getMessage()));
+                        .value(LOGIN_FAILED.getMessage()));
 
         //Login fail invalid email pattern
         loginRequest.setEmail("wrong");
@@ -146,9 +146,9 @@ public class AuthIntegrationTest {
                         .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message")
-                                .value(INVALID_REQUEST_BODY.getMessage()))
+                        .value(INVALID_REQUEST_BODY.getMessage()))
                 .andExpect(jsonPath("$.errors.email")
-                                .value("Invalid email pattern"));
+                        .value("Invalid email pattern"));
     }
 
     @DisplayName("[Auth][Integration] Logout test")
@@ -161,8 +161,8 @@ public class AuthIntegrationTest {
                 .build();
 
         mockMvc.perform(post("/api/auth/join")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(joinRequest)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest)))
                 .andExpect(status().isOk());
 
         LoginDto.Request loginRequest = LoginDto.Request.builder()
@@ -171,8 +171,8 @@ public class AuthIntegrationTest {
                 .build();
 
         MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(loginRequest)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isOk())
                 .andReturn();
 
@@ -183,19 +183,19 @@ public class AuthIntegrationTest {
         UUID memberId = jwtUtil.getIdFromToken(token);
 
         mockMvc.perform(post("/api/auth/logout")
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + token))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id")
-                                .value(memberId.toString()));
+                        .value(memberId.toString()));
 
         //Testing post method through invalid token
         mockMvc.perform(post("/api/auth/logout")
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + token))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.message")
-                                .value(UNAUTHORIZED.getMessage()));
+                        .value(UNAUTHORIZED.getMessage()));
     }
 
     @Test
@@ -229,22 +229,22 @@ public class AuthIntegrationTest {
 
         UUID memberId = jwtUtil.getIdFromToken(token);
 
-        mockMvc.perform(patch("/api/user/withdraw/"+memberId.toString())
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + token))
+        mockMvc.perform(patch("/api/user/withdraw/" + memberId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.email")
-                                .value(joinRequest.getEmail()))
+                        .value(joinRequest.getEmail()))
                 .andExpect(jsonPath("$.data.nickname")
-                                .value(joinRequest.getNickname()))
+                        .value(joinRequest.getNickname()))
                 .andExpect(jsonPath("$.data.withdrawnAt")
-                                .isNotEmpty());
+                        .isNotEmpty());
 
         mockMvc.perform(post("/api/auth/logout")
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + token))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.message")
-                                .value(UNAUTHORIZED.getMessage()));
+                        .value(UNAUTHORIZED.getMessage()));
     }
 }

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/integration/AuthIntegrationTest.java
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/integration/AuthIntegrationTest.java
@@ -1,0 +1,271 @@
+package com.kimtaeyang.mobidic.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kimtaeyang.mobidic.dto.JoinDto;
+import com.kimtaeyang.mobidic.dto.LoginDto;
+import com.kimtaeyang.mobidic.repository.MemberRepository;
+import com.kimtaeyang.mobidic.security.JwtUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+import static com.kimtaeyang.mobidic.code.AuthResponseCode.LOGIN_FAILED;
+import static com.kimtaeyang.mobidic.code.AuthResponseCode.UNAUTHORIZED;
+import static com.kimtaeyang.mobidic.code.GeneralResponseCode.INVALID_REQUEST_BODY;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AuthIntegrationTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @AfterEach
+    void cleanUp() {
+        memberRepository.deleteAll();
+    }
+
+    @DisplayName("[Auth][Integration] Join test")
+    @Test
+    @Transactional
+    void joinTest() throws Exception {
+        JoinDto.Request request = JoinDto.Request.builder()
+                .email("test@test.com")
+                .nickname("test")
+                .password("testTest1")
+                .build();
+
+        //Success
+        mockMvc.perform(post("/api/auth/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(
+                        jsonPath("$.data.email")
+                                .value("test@test.com"))
+                .andExpect(
+                        jsonPath("$.data.nickname")
+                                .value("test"));
+
+        request.setEmail("test@test");
+        request.setNickname("1");
+        request.setPassword("test");
+
+        HashMap<String, String> expectedErrors = new HashMap<>();
+        expectedErrors.put("email", "Invalid email pattern");
+        expectedErrors.put("nickname", "Invalid nickname pattern");
+        expectedErrors.put("password", "Invalid password pattern");
+
+        //Email, nickname, password format fail
+        mockMvc.perform(post("/api/auth/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(INVALID_REQUEST_BODY.getMessage()))
+                .andExpect(
+                        jsonPath("$.errors")
+                                .value(expectedErrors)
+                );
+    }
+
+    @DisplayName("[Auth][Integration] Login test")
+    @Test
+    void loginTest() throws Exception {
+        JoinDto.Request joinRequest = JoinDto.Request.builder()
+                .email("test@test.com")
+                .nickname("test")
+                .password("testTest1")
+                .build();
+
+        //Join
+        mockMvc.perform(post("/api/auth/join")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(joinRequest)))
+                .andExpect(status().isOk());
+
+        LoginDto.Request loginRequest = LoginDto.Request.builder()
+                .email(joinRequest.getEmail())
+                .password(joinRequest.getPassword())
+                .build();
+
+        //Login success
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String json = result.getResponse().getContentAsString();
+        String token = objectMapper.readTree(json).path("data").asText();
+
+        assertThat(jwtUtil.validateToken(token));
+
+        loginRequest.setPassword("wrongPassword");
+
+        //Login fail invalid password
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(LOGIN_FAILED.getMessage())
+                );
+
+        //Login fail invalid email
+        loginRequest.setEmail("wrong@email.com");
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(LOGIN_FAILED.getMessage())
+                );
+
+        //Login fail invalid email pattern
+        loginRequest.setEmail("wrong");
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(INVALID_REQUEST_BODY.getMessage()))
+                .andExpect(
+                        jsonPath("$.errors.email")
+                                .value("Invalid email pattern")
+                );
+    }
+
+    @DisplayName("[Auth][Integration] Logout test")
+    @Test
+    void logoutTest() throws Exception {
+        JoinDto.Request joinRequest = JoinDto.Request.builder()
+                .email("test@test.com")
+                .nickname("test")
+                .password("testTest1")
+                .build();
+
+        mockMvc.perform(post("/api/auth/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(joinRequest)))
+                .andExpect(status().isOk());
+
+        LoginDto.Request loginRequest = LoginDto.Request.builder()
+                .email(joinRequest.getEmail())
+                .password(joinRequest.getPassword())
+                .build();
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //Logout success
+        String loginJson = loginResult.getResponse().getContentAsString();
+        String token = objectMapper.readTree(loginJson).path("data").asText();
+
+        UUID memberId = jwtUtil.getIdFromToken(token);
+
+        mockMvc.perform(post("/api/auth/logout")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(
+                        jsonPath("$.data.id")
+                                .value(memberId.toString())
+                );
+
+        //Testing post method through invalid token
+        mockMvc.perform(post("/api/auth/logout")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token))
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(UNAUTHORIZED.getMessage())
+                );
+    }
+
+    @Test
+    @DisplayName("[Auth][Integration] Withdraw test")
+    public void withdrawTest() throws Exception {
+        JoinDto.Request joinRequest = JoinDto.Request.builder()
+                .email("test@test.com")
+                .nickname("test")
+                .password("testTest1")
+                .build();
+
+        mockMvc.perform(post("/api/auth/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest)))
+                .andExpect(status().isOk());
+
+        LoginDto.Request loginRequest = LoginDto.Request.builder()
+                .email(joinRequest.getEmail())
+                .password(joinRequest.getPassword())
+                .build();
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //Withdraw success
+        String loginJson = loginResult.getResponse().getContentAsString();
+        String token = objectMapper.readTree(loginJson).path("data").asText();
+
+        UUID memberId = jwtUtil.getIdFromToken(token);
+
+        mockMvc.perform(patch("/api/user/withdraw/"+memberId.toString())
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(
+                        jsonPath("$.data.email")
+                                .value(joinRequest.getEmail()))
+                .andExpect(
+                        jsonPath("$.data.nickname")
+                                .value(joinRequest.getNickname()))
+                .andExpect(
+                        jsonPath("$.data.withdrawnAt")
+                                .isNotEmpty());
+
+        mockMvc.perform(post("/api/auth/logout")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token))
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(UNAUTHORIZED.getMessage())
+                );
+    }
+}

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/integration/AuthIntegrationTest.java
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/integration/AuthIntegrationTest.java
@@ -63,11 +63,9 @@ public class AuthIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(
-                        jsonPath("$.data.email")
+                .andExpect(jsonPath("$.data.email")
                                 .value("test@test.com"))
-                .andExpect(
-                        jsonPath("$.data.nickname")
+                .andExpect(jsonPath("$.data.nickname")
                                 .value("test"));
 
         request.setEmail("test@test");
@@ -84,13 +82,10 @@ public class AuthIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(
-                        jsonPath("$.message")
+                .andExpect(jsonPath("$.message")
                                 .value(INVALID_REQUEST_BODY.getMessage()))
-                .andExpect(
-                        jsonPath("$.errors")
-                                .value(expectedErrors)
-                );
+                .andExpect(jsonPath("$.errors")
+                                .value(expectedErrors));
     }
 
     @DisplayName("[Auth][Integration] Login test")
@@ -132,10 +127,8 @@ public class AuthIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isUnauthorized())
-                .andExpect(
-                        jsonPath("$.message")
-                                .value(LOGIN_FAILED.getMessage())
-                );
+                .andExpect(jsonPath("$.message")
+                                .value(LOGIN_FAILED.getMessage()));
 
         //Login fail invalid email
         loginRequest.setEmail("wrong@email.com");
@@ -143,10 +136,8 @@ public class AuthIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isUnauthorized())
-                .andExpect(
-                        jsonPath("$.message")
-                                .value(LOGIN_FAILED.getMessage())
-                );
+                .andExpect(jsonPath("$.message")
+                                .value(LOGIN_FAILED.getMessage()));
 
         //Login fail invalid email pattern
         loginRequest.setEmail("wrong");
@@ -154,13 +145,10 @@ public class AuthIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isBadRequest())
-                .andExpect(
-                        jsonPath("$.message")
+                .andExpect(jsonPath("$.message")
                                 .value(INVALID_REQUEST_BODY.getMessage()))
-                .andExpect(
-                        jsonPath("$.errors.email")
-                                .value("Invalid email pattern")
-                );
+                .andExpect(jsonPath("$.errors.email")
+                                .value("Invalid email pattern"));
     }
 
     @DisplayName("[Auth][Integration] Logout test")
@@ -198,20 +186,16 @@ public class AuthIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
-                .andExpect(
-                        jsonPath("$.data.id")
-                                .value(memberId.toString())
-                );
+                .andExpect(jsonPath("$.data.id")
+                                .value(memberId.toString()));
 
         //Testing post method through invalid token
         mockMvc.perform(post("/api/auth/logout")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + token))
                 .andExpect(status().isUnauthorized())
-                .andExpect(
-                        jsonPath("$.message")
-                                .value(UNAUTHORIZED.getMessage())
-                );
+                .andExpect(jsonPath("$.message")
+                                .value(UNAUTHORIZED.getMessage()));
     }
 
     @Test
@@ -249,23 +233,18 @@ public class AuthIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
-                .andExpect(
-                        jsonPath("$.data.email")
+                .andExpect(jsonPath("$.data.email")
                                 .value(joinRequest.getEmail()))
-                .andExpect(
-                        jsonPath("$.data.nickname")
+                .andExpect(jsonPath("$.data.nickname")
                                 .value(joinRequest.getNickname()))
-                .andExpect(
-                        jsonPath("$.data.withdrawnAt")
+                .andExpect(jsonPath("$.data.withdrawnAt")
                                 .isNotEmpty());
 
         mockMvc.perform(post("/api/auth/logout")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + token))
                 .andExpect(status().isUnauthorized())
-                .andExpect(
-                        jsonPath("$.message")
-                                .value(UNAUTHORIZED.getMessage())
-                );
+                .andExpect(jsonPath("$.message")
+                                .value(UNAUTHORIZED.getMessage()));
     }
 }

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/integration/MemberIntegrationTest.java
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/integration/MemberIntegrationTest.java
@@ -1,0 +1,331 @@
+package com.kimtaeyang.mobidic.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kimtaeyang.mobidic.dto.JoinDto;
+import com.kimtaeyang.mobidic.dto.LoginDto;
+import com.kimtaeyang.mobidic.dto.UpdateNicknameDto;
+import com.kimtaeyang.mobidic.dto.UpdatePasswordDto;
+import com.kimtaeyang.mobidic.repository.MemberRepository;
+import com.kimtaeyang.mobidic.security.JwtUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.UUID;
+
+import static com.kimtaeyang.mobidic.code.AuthResponseCode.UNAUTHORIZED;
+import static com.kimtaeyang.mobidic.code.GeneralResponseCode.INVALID_REQUEST_BODY;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class MemberIntegrationTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @AfterEach
+    public void tearDown() {
+        memberRepository.deleteAll();
+    }
+
+    // Resource api integration test convention
+    //Success
+    // -> OK
+    //Fail without token
+    // -> UNAUTHORIZED
+    //Fail with unauthorized token
+    // -> UNAUTHORIZED
+    //Fail with no resource
+    // -> UNAUTHORIZED
+    //Fail with invalid pattern
+    // -> INVALID_REQUEST_BODY
+
+    @Test
+    @DisplayName("[Member][Integration] Get member detail")
+    void getMemberDetailTest() throws Exception {
+        JoinDto.Request joinRequest = JoinDto.Request.builder()
+                .email("test@test.com")
+                .nickname("test")
+                .password("testTest1")
+                .build();
+
+        mockMvc.perform(post("/api/auth/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest)))
+                .andExpect(status().isOk());
+
+        LoginDto.Request loginRequest = LoginDto.Request.builder()
+                .email(joinRequest.getEmail())
+                .password(joinRequest.getPassword())
+                .build();
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String json = loginResult.getResponse().getContentAsString();
+        String token = objectMapper.readTree(json).get("data").asText();
+        UUID memberId = jwtUtil.getIdFromToken(token);
+
+        //Success
+        mockMvc.perform(get("/api/user/detail")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .param("uId", memberId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(
+                        jsonPath("$.data.id")
+                                .value(memberId.toString()))
+                .andExpect(
+                        jsonPath("$.data.email")
+                                .value(joinRequest.getEmail()))
+                .andExpect(
+                        jsonPath("$.data.nickname")
+                                .value(joinRequest.getNickname()))
+                .andExpect(
+                        jsonPath("$.data.createdAt")
+                                .isNotEmpty());
+
+        //Fail without token
+        mockMvc.perform(get("/api/user/detail/" + memberId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with unauthorized token
+        mockMvc.perform(get("/api/user/detail")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + jwtUtil.generateToken(UUID.randomUUID()))
+                        .param("uId", memberId.toString()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with no resource
+        mockMvc.perform(get("/api/user/detail")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + jwtUtil.generateToken(UUID.randomUUID()))
+                        .param("uId", UUID.randomUUID().toString()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(UNAUTHORIZED.getMessage()));
+    }
+
+    @Test
+    @DisplayName("[Member][Integration] Update member nickname")
+    void updateMemberNicknameTest() throws Exception {
+        JoinDto.Request joinRequest = JoinDto.Request.builder()
+                .email("test@test.com")
+                .nickname("test")
+                .password("testTest1")
+                .build();
+
+        mockMvc.perform(post("/api/auth/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest)))
+                .andExpect(status().isOk());
+
+        LoginDto.Request loginRequest = LoginDto.Request.builder()
+                .email(joinRequest.getEmail())
+                .password(joinRequest.getPassword())
+                .build();
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String json = loginResult.getResponse().getContentAsString();
+        String token = objectMapper.readTree(json).get("data").asText();
+        UUID memberId = jwtUtil.getIdFromToken(token);
+
+        //Success
+        UpdateNicknameDto.Request updateNicknameRequest = UpdateNicknameDto.Request.builder()
+                .nickname(joinRequest.getNickname() + "test")
+                .build();
+
+        mockMvc.perform(patch("/api/user/nckchn/" + memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .content(objectMapper.writeValueAsString(updateNicknameRequest)))
+                .andExpect(status().isOk())
+                .andExpect(
+                        jsonPath("$.data.id")
+                                .value(memberId.toString()))
+                .andExpect(
+                        jsonPath("$.data.nickname")
+                                .value(updateNicknameRequest.getNickname()));
+
+        mockMvc.perform(get("/api/user/detail")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .param("uId", memberId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(
+                        jsonPath("$.data.nickname")
+                                .value(updateNicknameRequest.getNickname()));
+
+        //Fail without token
+        mockMvc.perform(patch("/api/user/nckchn/" + memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateNicknameRequest)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with unauthorized token
+        mockMvc.perform(patch("/api/user/nckchn/" + memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + jwtUtil.generateToken(UUID.randomUUID()))
+                        .content(objectMapper.writeValueAsString(updateNicknameRequest)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with no resource
+        mockMvc.perform(patch("/api/user/nckchn/" + UUID.randomUUID())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .content(objectMapper.writeValueAsString(updateNicknameRequest)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with invalid nickname pattern
+        updateNicknameRequest.setNickname(joinRequest.getNickname() + "testqweqweqqq");
+        mockMvc.perform(patch("/api/user/nckchn/" + memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .content(objectMapper.writeValueAsString(updateNicknameRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(INVALID_REQUEST_BODY.getMessage()))
+                .andExpect(
+                        jsonPath("$.errors.nickname")
+                                .value("Invalid nickname pattern"));
+
+    }
+
+    @Test
+    @DisplayName("[Member][Integration] Update member password")
+    void updateMemberPasswordTest() throws Exception {
+        JoinDto.Request joinRequest = JoinDto.Request.builder()
+                .email("test@test.com")
+                .nickname("test")
+                .password("testTest1")
+                .build();
+
+        mockMvc.perform(post("/api/auth/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest)))
+                .andExpect(status().isOk());
+
+        LoginDto.Request loginRequest = LoginDto.Request.builder()
+                .email(joinRequest.getEmail())
+                .password(joinRequest.getPassword())
+                .build();
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String json = loginResult.getResponse().getContentAsString();
+        String token = objectMapper.readTree(json).get("data").asText();
+        UUID memberId = jwtUtil.getIdFromToken(token);
+
+        UpdatePasswordDto.Request updatePasswordRequest = UpdatePasswordDto.Request.builder()
+                .password("testTest2")
+                .build();
+
+        //Fail without token
+        mockMvc.perform(patch("/api/user/pschn/" + memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatePasswordRequest)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with unauthorized token
+        mockMvc.perform(patch("/api/user/pschn/" + memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + jwtUtil.generateToken(UUID.randomUUID()))
+                        .content(objectMapper.writeValueAsString(updatePasswordRequest)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with no resource
+        mockMvc.perform(patch("/api/user/pschn/" + UUID.randomUUID())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .content(objectMapper.writeValueAsString(updatePasswordRequest)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with invalid nickname pattern
+        updatePasswordRequest.setPassword("test");
+        mockMvc.perform(patch("/api/user/pschn/" + memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .content(objectMapper.writeValueAsString(updatePasswordRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(INVALID_REQUEST_BODY.getMessage()))
+                .andExpect(
+                        jsonPath("$.errors.password")
+                                .value("Invalid password pattern"));
+
+        updatePasswordRequest.setPassword("testTest2");
+
+        //Success
+        mockMvc.perform(patch("/api/user/pschn/" + memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .content(objectMapper.writeValueAsString(updatePasswordRequest)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/user/detail")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .param("uId", memberId.toString()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(UNAUTHORIZED.getMessage()));
+    }
+}

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/integration/MemberIntegrationTest.java
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/integration/MemberIntegrationTest.java
@@ -68,26 +68,21 @@ public class MemberIntegrationTest {
                         .header("Authorization", "Bearer " + token)
                         .param("uId", memberId.toString()))
                 .andExpect(status().isOk())
-                .andExpect(
-                        jsonPath("$.data.id")
-                                .value(memberId.toString()))
-                .andExpect(
-                        jsonPath("$.data.email")
-                                .value(joinRequest.getEmail()))
-                .andExpect(
-                        jsonPath("$.data.nickname")
-                                .value(joinRequest.getNickname()))
-                .andExpect(
-                        jsonPath("$.data.createdAt")
-                                .isNotEmpty());
+                .andExpect(jsonPath("$.data.id")
+                        .value(memberId.toString()))
+                .andExpect(jsonPath("$.data.email")
+                        .value(joinRequest.getEmail()))
+                .andExpect(jsonPath("$.data.nickname")
+                        .value(joinRequest.getNickname()))
+                .andExpect(jsonPath("$.data.createdAt")
+                        .isNotEmpty());
 
         //Fail without token
         mockMvc.perform(get("/api/user/detail/" + memberId)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isUnauthorized())
-                .andExpect(
-                        jsonPath("$.message")
-                                .value(UNAUTHORIZED.getMessage()));
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
 
         //Fail with unauthorized token
         mockMvc.perform(get("/api/user/detail")
@@ -95,9 +90,8 @@ public class MemberIntegrationTest {
                         .header("Authorization", "Bearer " + jwtUtil.generateToken(UUID.randomUUID()))
                         .param("uId", memberId.toString()))
                 .andExpect(status().isUnauthorized())
-                .andExpect(
-                        jsonPath("$.message")
-                                .value(UNAUTHORIZED.getMessage()));
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
 
         //Fail with no resource
         mockMvc.perform(get("/api/user/detail")
@@ -105,9 +99,8 @@ public class MemberIntegrationTest {
                         .header("Authorization", "Bearer " + jwtUtil.generateToken(UUID.randomUUID()))
                         .param("uId", UUID.randomUUID().toString()))
                 .andExpect(status().isUnauthorized())
-                .andExpect(
-                        jsonPath("$.message")
-                                .value(UNAUTHORIZED.getMessage()));
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
     }
 
     @Test
@@ -149,30 +142,26 @@ public class MemberIntegrationTest {
                         .header("Authorization", "Bearer " + token)
                         .content(objectMapper.writeValueAsString(updateNicknameRequest)))
                 .andExpect(status().isOk())
-                .andExpect(
-                        jsonPath("$.data.id")
-                                .value(memberId.toString()))
-                .andExpect(
-                        jsonPath("$.data.nickname")
-                                .value(updateNicknameRequest.getNickname()));
+                .andExpect(jsonPath("$.data.id")
+                        .value(memberId.toString()))
+                .andExpect(jsonPath("$.data.nickname")
+                        .value(updateNicknameRequest.getNickname()));
 
         mockMvc.perform(get("/api/user/detail")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token)
                         .param("uId", memberId.toString()))
                 .andExpect(status().isOk())
-                .andExpect(
-                        jsonPath("$.data.nickname")
-                                .value(updateNicknameRequest.getNickname()));
+                .andExpect(jsonPath("$.data.nickname")
+                        .value(updateNicknameRequest.getNickname()));
 
         //Fail without token
         mockMvc.perform(patch("/api/user/nckchn/" + memberId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(updateNicknameRequest)))
                 .andExpect(status().isUnauthorized())
-                .andExpect(
-                        jsonPath("$.message")
-                                .value(UNAUTHORIZED.getMessage()));
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
 
         //Fail with unauthorized token
         mockMvc.perform(patch("/api/user/nckchn/" + memberId)
@@ -180,9 +169,8 @@ public class MemberIntegrationTest {
                         .header("Authorization", "Bearer " + jwtUtil.generateToken(UUID.randomUUID()))
                         .content(objectMapper.writeValueAsString(updateNicknameRequest)))
                 .andExpect(status().isUnauthorized())
-                .andExpect(
-                        jsonPath("$.message")
-                                .value(UNAUTHORIZED.getMessage()));
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
 
         //Fail with no resource
         mockMvc.perform(patch("/api/user/nckchn/" + UUID.randomUUID())
@@ -190,9 +178,8 @@ public class MemberIntegrationTest {
                         .header("Authorization", "Bearer " + token)
                         .content(objectMapper.writeValueAsString(updateNicknameRequest)))
                 .andExpect(status().isUnauthorized())
-                .andExpect(
-                        jsonPath("$.message")
-                                .value(UNAUTHORIZED.getMessage()));
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
 
         //Fail with invalid nickname pattern
         updateNicknameRequest.setNickname(joinRequest.getNickname() + "testqweqweqqq");
@@ -201,12 +188,10 @@ public class MemberIntegrationTest {
                         .header("Authorization", "Bearer " + token)
                         .content(objectMapper.writeValueAsString(updateNicknameRequest)))
                 .andExpect(status().isBadRequest())
-                .andExpect(
-                        jsonPath("$.message")
-                                .value(INVALID_REQUEST_BODY.getMessage()))
-                .andExpect(
-                        jsonPath("$.errors.nickname")
-                                .value("Invalid nickname pattern"));
+                .andExpect(jsonPath("$.message")
+                        .value(INVALID_REQUEST_BODY.getMessage()))
+                .andExpect(jsonPath("$.errors.nickname")
+                        .value("Invalid nickname pattern"));
 
     }
 
@@ -225,9 +210,8 @@ public class MemberIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(updatePasswordRequest)))
                 .andExpect(status().isUnauthorized())
-                .andExpect(
-                        jsonPath("$.message")
-                                .value(UNAUTHORIZED.getMessage()));
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
 
         //Fail with unauthorized token
         mockMvc.perform(patch("/api/user/pschn/" + memberId)
@@ -235,9 +219,8 @@ public class MemberIntegrationTest {
                         .header("Authorization", "Bearer " + jwtUtil.generateToken(UUID.randomUUID()))
                         .content(objectMapper.writeValueAsString(updatePasswordRequest)))
                 .andExpect(status().isUnauthorized())
-                .andExpect(
-                        jsonPath("$.message")
-                                .value(UNAUTHORIZED.getMessage()));
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
 
         //Fail with no resource
         mockMvc.perform(patch("/api/user/pschn/" + UUID.randomUUID())
@@ -245,9 +228,8 @@ public class MemberIntegrationTest {
                         .header("Authorization", "Bearer " + token)
                         .content(objectMapper.writeValueAsString(updatePasswordRequest)))
                 .andExpect(status().isUnauthorized())
-                .andExpect(
-                        jsonPath("$.message")
-                                .value(UNAUTHORIZED.getMessage()));
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
 
         //Fail with invalid nickname pattern
         updatePasswordRequest.setPassword("test");
@@ -256,12 +238,10 @@ public class MemberIntegrationTest {
                         .header("Authorization", "Bearer " + token)
                         .content(objectMapper.writeValueAsString(updatePasswordRequest)))
                 .andExpect(status().isBadRequest())
-                .andExpect(
-                        jsonPath("$.message")
-                                .value(INVALID_REQUEST_BODY.getMessage()))
-                .andExpect(
-                        jsonPath("$.errors.password")
-                                .value("Invalid password pattern"));
+                .andExpect(jsonPath("$.message")
+                        .value(INVALID_REQUEST_BODY.getMessage()))
+                .andExpect(jsonPath("$.errors.password")
+                        .value("Invalid password pattern"));
 
         updatePasswordRequest.setPassword("testTest2");
 
@@ -277,9 +257,8 @@ public class MemberIntegrationTest {
                         .header("Authorization", "Bearer " + token)
                         .param("uId", memberId.toString()))
                 .andExpect(status().isUnauthorized())
-                .andExpect(
-                        jsonPath("$.message")
-                                .value(UNAUTHORIZED.getMessage()));
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
     }
 
     private String loginAndGetToken() throws Exception {

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/integration/MemberIntegrationTest.java
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/integration/MemberIntegrationTest.java
@@ -45,18 +45,6 @@ public class MemberIntegrationTest {
         memberRepository.deleteAll();
     }
 
-    // Resource api integration test convention
-    //Success
-    // -> OK
-    //Fail without token
-    // -> UNAUTHORIZED
-    //Fail with unauthorized token
-    // -> UNAUTHORIZED
-    //Fail with no resource
-    // -> UNAUTHORIZED
-    //Fail with invalid pattern
-    // -> INVALID_REQUEST_BODY
-
     @Test
     @DisplayName("[Member][Integration] Get member detail")
     void getMemberDetailTest() throws Exception {
@@ -329,3 +317,14 @@ public class MemberIntegrationTest {
                                 .value(UNAUTHORIZED.getMessage()));
     }
 }
+// Resource api integration test convention
+//Success
+// -> OK
+//Fail without token
+// -> UNAUTHORIZED
+//Fail with unauthorized token
+// -> UNAUTHORIZED
+//Fail with no resource
+// -> UNAUTHORIZED
+//Fail with invalid pattern
+// -> INVALID_REQUEST_BODY

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/integration/VocabIntegrationTest.java
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/integration/VocabIntegrationTest.java
@@ -1,0 +1,444 @@
+package com.kimtaeyang.mobidic.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kimtaeyang.mobidic.dto.AddVocabDto;
+import com.kimtaeyang.mobidic.dto.JoinDto;
+import com.kimtaeyang.mobidic.dto.LoginDto;
+import com.kimtaeyang.mobidic.dto.UpdateVocabDto;
+import com.kimtaeyang.mobidic.repository.MemberRepository;
+import com.kimtaeyang.mobidic.repository.VocabRepository;
+import com.kimtaeyang.mobidic.security.JwtUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.UUID;
+
+import static com.kimtaeyang.mobidic.code.AuthResponseCode.UNAUTHORIZED;
+import static com.kimtaeyang.mobidic.code.GeneralResponseCode.INVALID_REQUEST_BODY;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class VocabIntegrationTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private VocabRepository vocabRepository;
+
+    @AfterEach
+    void tearDown() {
+        memberRepository.deleteAll();
+        vocabRepository.deleteAll();
+    }
+
+    private final JoinDto.Request joinRequest = JoinDto.Request.builder()
+            .email("test@test.com")
+            .nickname("test")
+            .password("testTest1")
+            .build();
+
+    private final LoginDto.Request loginRequest = LoginDto.Request.builder()
+            .email(joinRequest.getEmail())
+            .password(joinRequest.getPassword())
+            .build();
+
+    @Test
+    @DisplayName("[Vocab][Integration] Add vocab test")
+    void addVocabTest() throws Exception {
+        String token = loginAndGetToken();
+        UUID memberId = jwtUtil.getIdFromToken(token);
+
+        AddVocabDto.Request addVocabRequest = AddVocabDto.Request.builder()
+                .title("title")
+                .description("description")
+                .build();
+
+        //Success
+        mockMvc.perform(post("/api/vocab/" + memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(addVocabRequest))
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(
+                        jsonPath("$.data.title")
+                                .value(addVocabRequest.getTitle()))
+                .andExpect(
+                        jsonPath("$.data.description")
+                                .value(addVocabRequest.getDescription()))
+                .andExpect(
+                        jsonPath("$.data.id")
+                                .isNotEmpty());
+
+        //Fail without token
+        mockMvc.perform(post("/api/vocab/" + memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(addVocabRequest)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with unauthorized token
+        mockMvc.perform(post("/api/vocab/" + memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + jwtUtil.generateToken(UUID.randomUUID()))
+                        .content(objectMapper.writeValueAsString(addVocabRequest)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with unauthorized token
+        mockMvc.perform(post("/api/vocab/" + UUID.randomUUID())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .content(objectMapper.writeValueAsString(addVocabRequest)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with invalid pattern
+        addVocabRequest.setTitle(UUID.randomUUID().toString());
+        addVocabRequest.setDescription(UUID.randomUUID().toString() + UUID.randomUUID());
+        mockMvc.perform(post("/api/vocab/" + UUID.randomUUID())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .content(objectMapper.writeValueAsString(addVocabRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(
+                        jsonPath("$.message")
+                                .value(INVALID_REQUEST_BODY.getMessage()))
+                .andExpect(
+                        jsonPath("$.errors.title")
+                                .value("Invalid title pattern"))
+                .andExpect(
+                        jsonPath("$.errors.description")
+                                .value("Invalid description pattern"));
+    }
+
+    @Test
+    @DisplayName("[Vocab][Integration] Get vocabs by member id test")
+    void getVocabsByMemberIdTest() throws Exception {
+        String token = loginAndGetToken();
+        UUID memberId = jwtUtil.getIdFromToken(token);
+
+        AddVocabDto.Request addVocabRequest = AddVocabDto.Request.builder()
+                .title("title")
+                .description("description")
+                .build();
+
+        mockMvc.perform(post("/api/vocab/" + memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(addVocabRequest))
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+
+        //Success
+        mockMvc.perform(get("/api/vocab/all")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .param("uId", memberId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].title")
+                        .value(addVocabRequest.getTitle()))
+                .andExpect(jsonPath("$.data[0].description")
+                        .value(addVocabRequest.getDescription()));
+
+        //Fail without token
+        mockMvc.perform(get("/api/vocab/all")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("uId", memberId.toString()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with unauthorized token
+        mockMvc.perform(get("/api/vocab/all")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + jwtUtil.generateToken(UUID.randomUUID()))
+                        .param("uId", memberId.toString()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with no resource
+        mockMvc.perform(get("/api/vocab/all")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("uId", UUID.randomUUID().toString())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
+    }
+
+    @Test
+    @DisplayName("[Vocab][Integration] Get vocab by id test")
+    void getVocabByIdTest() throws Exception {
+        String token = loginAndGetToken();
+        UUID memberId = jwtUtil.getIdFromToken(token);
+
+        AddVocabDto.Request addVocabRequest = AddVocabDto.Request.builder()
+                .title("title")
+                .description("description")
+                .build();
+
+        MvcResult addResult = mockMvc.perform(post("/api/vocab/" + memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(addVocabRequest))
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String json = addResult.getResponse().getContentAsString();
+        AddVocabDto.Response addVocabResponse = objectMapper.convertValue(
+                objectMapper.readTree(json).path("data"), AddVocabDto.Response.class
+        );
+
+        //Success
+        mockMvc.perform(get("/api/vocab/detail")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .param("vId", addVocabResponse.getId().toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id")
+                        .value(addVocabResponse.getId().toString()))
+                .andExpect(jsonPath("$.data.memberId")
+                        .value(memberId.toString()))
+                .andExpect(jsonPath("$.data.title")
+                        .value(addVocabRequest.getTitle()))
+                .andExpect(jsonPath("$.data.description")
+                        .value(addVocabRequest.getDescription()))
+                .andExpect(jsonPath("$.data.createdAt")
+                        .isNotEmpty());
+
+        //Fail without token
+        mockMvc.perform(get("/api/vocab/detail")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("vId", addVocabResponse.getId().toString()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with unauthorized token
+        mockMvc.perform(get("/api/vocab/detail")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + jwtUtil.generateToken(UUID.randomUUID()))
+                        .param("vId", addVocabResponse.getId().toString()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with no resource
+        mockMvc.perform(get("/api/vocab/detail")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .param("vId", UUID.randomUUID().toString()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
+    }
+
+    @Test
+    @DisplayName("[Vocab][Integration] Update vocab test")
+    void updateVocabTest() throws Exception {
+        String token = loginAndGetToken();
+        UUID memberId = jwtUtil.getIdFromToken(token);
+
+        AddVocabDto.Request addVocabRequest = AddVocabDto.Request.builder()
+                .title("title")
+                .description("description")
+                .build();
+
+        MvcResult addResult = mockMvc.perform(post("/api/vocab/" + memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(addVocabRequest))
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String json = addResult.getResponse().getContentAsString();
+        AddVocabDto.Response addVocabResponse = objectMapper.convertValue(
+                objectMapper.readTree(json).path("data"), AddVocabDto.Response.class
+        );
+
+        UpdateVocabDto.Request updateVocabRequest = UpdateVocabDto.Request.builder()
+                .title("title2")
+                .description("description2")
+                .build();
+
+        //Fail without token
+        mockMvc.perform(patch("/api/vocab/" + addVocabResponse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateVocabRequest)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with unauthorized token
+        mockMvc.perform(patch("/api/vocab/" + addVocabResponse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + jwtUtil.generateToken(UUID.randomUUID()))
+                        .content(objectMapper.writeValueAsString(updateVocabRequest)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with no resource
+        mockMvc.perform(patch("/api/vocab/" + UUID.randomUUID())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .content(objectMapper.writeValueAsString(updateVocabRequest)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
+
+        //Success
+        mockMvc.perform(patch("/api/vocab/" + addVocabResponse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .content(objectMapper.writeValueAsString(updateVocabRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title")
+                        .value(updateVocabRequest.getTitle()))
+                .andExpect(jsonPath("$.data.description")
+                        .value(updateVocabRequest.getDescription()));
+
+        //Fail with invalid pattern
+        updateVocabRequest.setTitle(UUID.randomUUID().toString());
+        updateVocabRequest.setDescription(UUID.randomUUID().toString() + UUID.randomUUID());
+        System.out.println(updateVocabRequest.getDescription() + ", " + updateVocabRequest.getDescription().length());
+        mockMvc.perform(patch("/api/vocab/" + addVocabResponse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .content(objectMapper.writeValueAsString(updateVocabRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message")
+                        .value(INVALID_REQUEST_BODY.getMessage()))
+                .andExpect(jsonPath("$.errors.title")
+                        .value("Invalid title pattern"))
+                .andExpect(jsonPath("$.errors.description")
+                        .value("Invalid description pattern"));
+    }
+
+    @Test
+    @DisplayName("[Vocab][Integration] Delete vocab test")
+    void deleteVocabTest() throws Exception {
+        String token = loginAndGetToken();
+        UUID memberId = jwtUtil.getIdFromToken(token);
+
+        AddVocabDto.Request addVocabRequest = AddVocabDto.Request.builder()
+                .title("title")
+                .description("description")
+                .build();
+
+        MvcResult addResult = mockMvc.perform(post("/api/vocab/" + memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(addVocabRequest))
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String json = addResult.getResponse().getContentAsString();
+        AddVocabDto.Response addVocabResponse = objectMapper.convertValue(
+                objectMapper.readTree(json).path("data"), AddVocabDto.Response.class
+        );
+
+        //Fail without token
+        mockMvc.perform(delete("/api/vocab/" + addVocabResponse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("vocabId", addVocabResponse.getId().toString()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with unauthorized token
+        mockMvc.perform(delete("/api/vocab/" + addVocabResponse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + jwtUtil.generateToken(UUID.randomUUID()))
+                        .param("vocabId", addVocabResponse.getId().toString()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
+
+        //Fail with no resource
+        mockMvc.perform(delete("/api/vocab/" + UUID.randomUUID())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .param("vocabId", addVocabResponse.getId().toString()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
+
+        //Success
+        mockMvc.perform(delete("/api/vocab/" + addVocabResponse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .param("vocabId", addVocabResponse.getId().toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id")
+                        .value(addVocabResponse.getId().toString()))
+                .andExpect(jsonPath("$.data.title")
+                        .value(addVocabRequest.getTitle()))
+                .andExpect(jsonPath("$.data.description")
+                        .value(addVocabRequest.getDescription()))
+                .andExpect(jsonPath("$.data.createdAt")
+                        .isNotEmpty())
+                .andExpect(jsonPath("$.data.memberId")
+                        .isNotEmpty());
+
+        mockMvc.perform(get("/api/vocab/detail")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
+                        .param("vId", addVocabResponse.getId().toString()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message")
+                        .value(UNAUTHORIZED.getMessage()));
+    }
+
+    private String loginAndGetToken() throws Exception {
+        mockMvc.perform(post("/api/auth/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest)))
+                .andExpect(status().isOk());
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String json = loginResult.getResponse().getContentAsString();
+        return objectMapper.readTree(json).get("data").asText();
+    }
+}
+// Resource api integration test convention
+//Success
+// -> OK
+//Fail without token
+// -> UNAUTHORIZED
+//Fail with unauthorized token
+// -> UNAUTHORIZED
+//Fail with no resource
+// -> UNAUTHORIZED
+//Fail with invalid pattern
+// -> INVALID_REQUEST_BODY

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/service/MemberServiceTest.java
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/service/MemberServiceTest.java
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/service/MemberServiceTest.java
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/service/MemberServiceTest.java
@@ -158,7 +158,7 @@ class MemberServiceTest {
                 });
 
         //when
-        memberService.updateMemberPassword(UUID.fromString(UID), request, UUID.randomUUID());
+        memberService.updateMemberPassword(UUID.fromString(UID), request, UUID.randomUUID().toString());
 
         //then
         verify(memberRepository, times(1))

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/service/MemberServiceTest.java
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/service/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.kimtaeyang.mobidic.service;
 
+import com.kimtaeyang.mobidic.dto.LogoutDto;
 import com.kimtaeyang.mobidic.dto.MemberDto;
 import com.kimtaeyang.mobidic.dto.UpdateNicknameDto;
 import com.kimtaeyang.mobidic.dto.UpdatePasswordDto;
@@ -146,7 +147,8 @@ class MemberServiceTest {
         //given
         given(memberRepository.findById(any(UUID.class)))
                 .willReturn(Optional.of(defaultMember));
-        willDoNothing().given(authService).logout(any(UUID.class), anyString());
+        given(authService.logout(any(UUID.class), anyString()))
+                .willReturn(Mockito.mock(LogoutDto.Response.class));
         given(memberRepository.save(any(Member.class)))
                 .willAnswer(invocation -> {
                     Member memberArg = invocation.getArgument(0);

--- a/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/service/MemberServiceTest.java
+++ b/mobidic_spring/src/test/java/com/kimtaeyang/mobidic/service/MemberServiceTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -47,6 +48,9 @@ class MemberServiceTest {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    AuthService authService;
 
     private static final String UID = "9f81b0d7-2f8e-4ad3-ae18-41c73dc71b39";
 
@@ -142,6 +146,7 @@ class MemberServiceTest {
         //given
         given(memberRepository.findById(any(UUID.class)))
                 .willReturn(Optional.of(defaultMember));
+        willDoNothing().given(authService).logout(any(UUID.class), anyString());
         given(memberRepository.save(any(Member.class)))
                 .willAnswer(invocation -> {
                     Member memberArg = invocation.getArgument(0);
@@ -151,7 +156,7 @@ class MemberServiceTest {
                 });
 
         //when
-        memberService.updateMemberPassword(UUID.fromString(UID), request);
+        memberService.updateMemberPassword(UUID.fromString(UID), request, UUID.randomUUID());
 
         //then
         verify(memberRepository, times(1))
@@ -177,9 +182,14 @@ class MemberServiceTest {
         public PasswordEncoder passwordEncoder() {
             return new BCryptPasswordEncoder();
         }
+
+        @Bean
+        public AuthService authService() {
+            return Mockito.mock(AuthService.class);
+        }
     }
 
-    private void resetMock(){
+    private void resetMock() {
         Mockito.reset(memberRepository);
     }
 }


### PR DESCRIPTION
[fix: Response code enum 수정]
- validation 진행 시 status code 400 코드로 변경 및 FieldError 활용

[fix: Email pattern validation 수정]
- @Email이 아닌 regexp를 통한 validation

[test: 인증 관련 통합테스트]
- Login, Join, Logout 통합테스트 완료

[test: Member service 통합 테스트]
- security context까지 고려해서 테스트 완료

[test: Vocab service 통합 테스트]
- security context까지 고려해서 테스트 완료