### PR TITLE
Feature/login page UI

### DIFF
--- a/.idea/mobile-dictionary.iml
+++ b/.idea/mobile-dictionary.iml
@@ -2,7 +2,11 @@
 <module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/mobidic_flutter/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/mobidic_flutter/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/mobidic_flutter/build" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />

--- a/mobidic_flutter/lib/Dictation.dart
+++ b/mobidic_flutter/lib/Dictation.dart
@@ -1,159 +1,105 @@
 import 'package:flutter/material.dart';
 
-class DictationPage extends StatelessWidget {
+class DictationQuizPage extends StatefulWidget {
+  const DictationQuizPage({super.key});
+
   @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.lightBlue.shade100,
-      body: SafeArea(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            SizedBox(height: 20),
-            Text(
-              '받아쓰기',
-              style: TextStyle(
-                fontSize: 28,
-                fontFamily: 'Baloo2',
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            SizedBox(height: 20),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Row(
-                children: [
-                  IconButton(
-                    icon: Icon(Icons.arrow_back),
-                    onPressed: () {
-                      Navigator.pop(context);
-                    },
-                  ),
-                  Text(
-                    '받아쓰기 - eazy',
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontFamily: 'MPlusRounded1c',
-                    ),
-                  ),
-                  Spacer(),
-                  IconButton(
-                    icon: Icon(Icons.home),
-                    onPressed: () {
-                      // 홈으로 이동하는 기능은 나중에 추가
-                    },
-                  ),
-                ],
-              ),
-            ),
-            SizedBox(height: 30),
-            Container(
-              margin: EdgeInsets.symmetric(horizontal: 32),
-              padding: EdgeInsets.all(24),
-              decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.8),
-                borderRadius: BorderRadius.circular(20),
-              ),
-              child: Column(
-                children: [
-                  Icon(Icons.volume_up, size: 40),
-                  SizedBox(height: 10),
-                  Text(
-                    '들리는 단어를 써보세요',
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontFamily: 'MPlusRounded1c',
-                    ),
-                  ),
-                  SizedBox(height: 20),
-                  Container(
-                    height: 40,
-                    width: double.infinity,
-                    decoration: BoxDecoration(
-                      border: Border.all(color: Colors.black),
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    alignment: Alignment.center,
-                    child: Text(''), // 입력 기능은 아직 없음
-                  ),
-                ],
-              ),
-            ),
-            SizedBox(height: 30),
-            Text(
-              '오답률 : 20%',
-              style: TextStyle(
-                fontSize: 18,
-                fontFamily: 'MPlusRounded1c',
-              ),
-            ),
-            SizedBox(height: 10),
-            Switch(
-              value: false,
-              onChanged: (value) {},
-            ),
-            SizedBox(height: 5),
-            Container(
-              padding: EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-              decoration: BoxDecoration(
-                color: Colors.white,
-                border: Border.all(color: Colors.black),
-                borderRadius: BorderRadius.circular(10),
-              ),
-              child: Text(
-                '뜻 / 영단어 변경',
-                style: TextStyle(
-                  fontFamily: 'MPlusRounded1c',
-                  fontSize: 14,
-                ),
-              ),
-            ),
-            Spacer(),
-            GestureDetector(
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => NextPage()), // NEXT 버튼 누르면 이동!
-                );
-              },
-              child: Container(
-                margin: EdgeInsets.symmetric(horizontal: 32, vertical: 16),
-                width: double.infinity,
-                padding: EdgeInsets.symmetric(vertical: 14),
-                decoration: BoxDecoration(
-                  color: Colors.white,
-                  borderRadius: BorderRadius.circular(30),
-                ),
-                child: Center(
-                  child: Text(
-                    'NEXT',
-                    style: TextStyle(
-                      fontSize: 20,
-                      fontFamily: 'Baloo2',
-                    ),
-                  ),
-                ),
-              ),
+  State<DictationQuizPage> createState() => _DictationQuizPageState();
+}
+
+class _DictationQuizPageState extends State<DictationQuizPage> {
+  final TextEditingController _controller = TextEditingController();
+
+  void _checkAnswer() {
+    String input = _controller.text.trim().toLowerCase();
+
+    if (input == 'apple') {
+      showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text("정답입니다!! 🎉"),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text("확인"),
             ),
           ],
         ),
-      ),
-    );
+      );
+    } else {
+      showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text("오답입니다. 😢"),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text("다시 시도"),
+            ),
+          ],
+        ),
+      );
+    }
   }
-}
 
-// NEXT 버튼 누르면 이동할 "임시 페이지" 만들기
-class NextPage extends StatelessWidget {
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('다음 화면'),
+        title: const Text('받아쓰기 퀴즈'),
+        centerTitle: true,
+        backgroundColor: Colors.deepPurple,
       ),
-      body: Center(
-        child: Text(
-          '여기는 다음 화면입니다!',
-          style: TextStyle(fontSize: 24),
+      body: Padding(
+        padding: const EdgeInsets.all(32.0),
+        child: Column(
+          children: [
+            const SizedBox(height: 40),
+
+            const Icon(Icons.volume_up, size: 64, color: Colors.deepPurple),
+
+            const SizedBox(height: 24),
+
+            // '정답 입력' 텍스트
+            const Text(
+              '정답 입력',
+              style: TextStyle(fontSize: 20),
+            ),
+
+            const SizedBox(height: 24),
+
+            // 네모 박스 (입력창)
+            TextField(
+              controller: _controller,
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 24),
+              decoration: InputDecoration(
+                hintText: '여기에 입력하세요',
+                contentPadding: const EdgeInsets.symmetric(vertical: 20),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              onSubmitted: (_) => _checkAnswer(), // 엔터로도 제출
+            ),
+
+            const SizedBox(height: 32),
+
+            ElevatedButton(
+              onPressed: _checkAnswer,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.deepPurple,
+                padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
+              ),
+              child: const Text("제출하기", style: TextStyle(fontSize: 18)),
+            ),
+          ],
         ),
       ),
     );

--- a/mobidic_flutter/lib/Dictation.dart
+++ b/mobidic_flutter/lib/Dictation.dart
@@ -7,39 +7,68 @@ class DictationQuizPage extends StatefulWidget {
   State<DictationQuizPage> createState() => _DictationQuizPageState();
 }
 
-class _DictationQuizPageState extends State<DictationQuizPage> { //빈칸채우기
+class _DictationQuizPageState extends State<DictationQuizPage> {
   final TextEditingController _controller = TextEditingController();
+
+  final List<String> answers = ['apple', 'blue', 'call'];
+  int currentIndex = 0;
+  int correctCount = 0;
+  int totalCount = 0;
 
   void _checkAnswer() {
     String input = _controller.text.trim().toLowerCase();
+    String correctAnswer = answers[currentIndex];
 
-    if (input == 'apple') {
-      showDialog(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text("정답입니다!! 🎉"),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text("확인"),
-            ),
-          ],
-        ),
-      );
-    } else {
-      showDialog(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text("오답입니다. 😢"),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text("다시 시도"),
-            ),
-          ],
-        ),
-      );
-    }
+    bool isCorrect = input == correctAnswer;
+    setState(() {
+      totalCount++;
+      if (isCorrect) correctCount++;
+    });
+
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: Text(isCorrect ? "정답입니다!! 🎉" : "오답입니다. 😢"),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.pop(context);
+              setState(() {
+                if (currentIndex < answers.length - 1) {
+                  currentIndex++;
+                  _controller.clear();
+                } else {
+                  _showCompletionDialog();
+                }
+              });
+            },
+            child: const Text("다음 문제"),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showCompletionDialog() {
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text("🎉 퀴즈 완료!"),
+        content: Text("총 정답률: ${_getAccuracyText()}"),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text("닫기"),
+          )
+        ],
+      ),
+    );
+  }
+
+  String _getAccuracyText() {
+    if (totalCount == 0) return "0% (0 / 0)";
+    double percent = (correctCount / totalCount) * 100;
+    return "${percent.toStringAsFixed(1)}% ($correctCount / $totalCount)";
   }
 
   @override
@@ -53,53 +82,88 @@ class _DictationQuizPageState extends State<DictationQuizPage> { //빈칸채우�
     return Scaffold(
       appBar: AppBar(
         title: const Text('받아쓰기 퀴즈'),
+        backgroundColor: Colors.blue,
+        foregroundColor: Colors.white,
         centerTitle: true,
-        backgroundColor: Colors.deepPurple,
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(32.0),
-        child: Column(
-          children: [
-            const SizedBox(height: 40),
-
-            const Icon(Icons.volume_up, size: 64, color: Colors.deepPurple),
-
-            const SizedBox(height: 24),
-
-            // '정답 입력' 텍스트
-            const Text(
-              '정답 입력',
-              style: TextStyle(fontSize: 20),
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(30),
+          child: Padding(
+            padding: const EdgeInsets.only(bottom: 8.0, right: 16.0),
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: Text(
+                '정답률: ${_getAccuracyText()}',
+                style: const TextStyle(color: Colors.white, fontSize: 14),
+              ),
             ),
-
-            const SizedBox(height: 24),
-
-            // 네모 박스 (입력창)
-            TextField(
-              controller: _controller,
-              textAlign: TextAlign.center,
-              style: const TextStyle(fontSize: 24),
-              decoration: InputDecoration(
-                hintText: '여기에 입력하세요',
-                contentPadding: const EdgeInsets.symmetric(vertical: 20),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(12),
+          ),
+        ),
+      ),
+      body: Container(
+        width: double.infinity,
+        height: double.infinity,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              Color(0xFFb2ebf2),
+              Color(0xFF81d4fa),
+              Color(0xFF4fc3f7),
+            ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(32.0),
+          child: Column(
+            children: [
+              const SizedBox(height: 40),
+              const Icon(Icons.volume_up, size: 64, color: Colors.blue),
+              const SizedBox(height: 24),
+              const Text('정답 입력', style: TextStyle(fontSize: 20)),
+              const SizedBox(height: 24),
+              TextField(
+                controller: _controller,
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontSize: 24),
+                decoration: InputDecoration(
+                  hintText: '여기에 입력하세요',
+                  contentPadding: const EdgeInsets.symmetric(vertical: 20),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                onSubmitted: (_) => _checkAnswer(),
+              ),
+              const SizedBox(height: 32),
+              ElevatedButton(
+                onPressed: _checkAnswer,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.blue,
+                  padding:
+                  const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
+                ),
+                child: const Text(
+                  "제출하기",
+                  style: TextStyle(fontSize: 18, color: Colors.white),
                 ),
               ),
-              onSubmitted: (_) => _checkAnswer(), // 엔터로도 제출
-            ),
-
-            const SizedBox(height: 32),
-
-            ElevatedButton(
-              onPressed: _checkAnswer,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.deepPurple,
-                padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
-              ),
-              child: const Text("제출하기", style: TextStyle(fontSize: 18)),
-            ),
-          ],
+            ],
+          ),
+        ),
+      ),
+      bottomNavigationBar: BottomAppBar(
+        color: Colors.grey[300],
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: const [
+              Icon(Icons.note, color: Colors.black),
+              Icon(Icons.home, color: Colors.black),
+              Icon(Icons.exit_to_app, color: Colors.black),
+            ],
+          ),
         ),
       ),
     );

--- a/mobidic_flutter/lib/Dictation.dart
+++ b/mobidic_flutter/lib/Dictation.dart
@@ -7,7 +7,7 @@ class DictationQuizPage extends StatefulWidget {
   State<DictationQuizPage> createState() => _DictationQuizPageState();
 }
 
-class _DictationQuizPageState extends State<DictationQuizPage> {
+class _DictationQuizPageState extends State<DictationQuizPage> { //빈칸채우기
   final TextEditingController _controller = TextEditingController();
 
   void _checkAnswer() {

--- a/mobidic_flutter/lib/Fill_blank.dart
+++ b/mobidic_flutter/lib/Fill_blank.dart
@@ -7,7 +7,7 @@ class FillBlankPage extends StatefulWidget {
   State<FillBlankPage> createState() => _FillBlankPageState();
 }
 
-class _FillBlankPageState extends State<FillBlankPage> {
+class _FillBlankPageState extends State<FillBlankPage> {    //리스트
   final List<Map<String, dynamic>> quizList = [
     {
       'word': 'apple',

--- a/mobidic_flutter/lib/Fill_blank.dart
+++ b/mobidic_flutter/lib/Fill_blank.dart
@@ -1,127 +1,194 @@
 import 'package:flutter/material.dart';
 
-class Fill_blank extends StatefulWidget {
+class FillBlankPage extends StatefulWidget {
+  const FillBlankPage({super.key});
+
   @override
-  _Fill_blankState createState() => _Fill_blankState();
+  State<FillBlankPage> createState() => _FillBlankPageState();
 }
 
-class _Fill_blankState extends State<Fill_blank> {
-  final TextEditingController answerController = TextEditingController();
-  String resultText = '';
+class _FillBlankPageState extends State<FillBlankPage> {
+  final List<Map<String, dynamic>> quizList = [
+    {
+      'word': 'apple',
+      'meaning': '사과',
+      'revealed': [false, false, false, true, true],
+    },
+    {
+      'word': 'cat',
+      'meaning': '고양이',
+      'revealed': [false, false, false],
+    },
+    {
+      'word': 'human',
+      'meaning': '사람',
+      'revealed': [false, true, false, false, true],
+    },
+  ];
+
+  int currentIndex = 0;
+  List<String> userInput = [];
+  List<TextEditingController> controllers = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _setupCurrentQuestion();
+  }
+
+  void _setupCurrentQuestion() {
+    final quiz = quizList[currentIndex];
+    userInput = List.generate(quiz['word'].length, (_) => '');
+    controllers = List.generate(
+      quiz['word'].length,
+          (_) => TextEditingController(),
+    );
+  }
 
   void checkAnswer() {
-    String userAnswer = answerController.text.trim().toLowerCase();
-    if (userAnswer == 'apple') {
-      setState(() {
-        resultText = 'Correct!!';
-      });
+    final quiz = quizList[currentIndex];
+    final String word = quiz['word'];
+    final List<bool> revealed = quiz['revealed'];
+
+    String answer = '';
+    for (int i = 0; i < word.length; i++) {
+      answer += revealed[i] ? word[i] : (userInput[i].toLowerCase());
+    }
+
+    if (answer == word) {
+      showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text('정답입니다!! 🎉'),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context);
+                setState(() {
+                  if (currentIndex < quizList.length - 1) {
+                    currentIndex++;
+                    _setupCurrentQuestion();
+                  } else {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text("퀴즈 완료!")),
+                    );
+                  }
+                });
+              },
+              child: const Text("다음 문제"),
+            )
+          ],
+        ),
+      );
     } else {
-      setState(() {
-        resultText = 'Try again..';
-      });
+      showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text('다시 생각해보세요. 😢'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('확인'),
+            )
+          ],
+        ),
+      );
     }
   }
 
   @override
+  void dispose() {
+    for (final controller in controllers) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final quiz = quizList[currentIndex];
+    final String word = quiz['word'];
+    final String meaning = quiz['meaning'];
+    final List<bool> revealed = quiz['revealed'];
+
     return Scaffold(
-      backgroundColor: Colors.lightBlue.shade100,
-      body: SafeArea(
+      appBar: AppBar(
+        title: const Text('빈칸 채우기'),
+        centerTitle: true,
+        backgroundColor: Colors.teal,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(32.0),
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            SizedBox(height: 20),
-            Text(
-              '받아쓰기',
-              style: TextStyle(
-                fontSize: 28,
-                fontFamily: 'Baloo2',
-                fontWeight: FontWeight.bold,
-              ),
+            const SizedBox(height: 40),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: List.generate(word.length, (i) {
+                if (revealed[i]) {
+                  return _buildLetterBox(word[i], isRevealed: true);
+                } else {
+                  return _buildInputBox(i);
+                }
+              }),
             ),
-            SizedBox(height: 20),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Row(
-                children: [
-                  IconButton(
-                    icon: Icon(Icons.arrow_back),
-                    onPressed: () {
-                      Navigator.pop(context);
-                    },
-                  ),
-                  Text(
-                    '빈칸 채우기',
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontFamily: 'MPlusRounded1c',
-                    ),
-                  ),
-                  Spacer(),
-                  IconButton(
-                    icon: Icon(Icons.home),
-                    onPressed: () {
-                      // 홈 이동 기능 추가 예정
-                    },
-                  ),
-                ],
-              ),
-            ),
-            SizedBox(height: 60),
-            Text(
-              '사과',
-              style: TextStyle(
-                fontSize: 32,
-                fontFamily: 'MPlusRounded1c',
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            SizedBox(height: 40),
-            Container(
-              margin: EdgeInsets.symmetric(horizontal: 32),
-              child: TextField(
-                controller: answerController,
-                decoration: InputDecoration(
-                  hintText: '정답 입력',
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  filled: true,
-                  fillColor: Colors.white,
-                ),
-              ),
-            ),
-            SizedBox(height: 20),
+            const SizedBox(height: 40),
+            Text('뜻: $meaning', style: const TextStyle(fontSize: 20)),
+            const SizedBox(height: 40),
             ElevatedButton(
               onPressed: checkAnswer,
               style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.white,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(30),
-                ),
-                padding: EdgeInsets.symmetric(horizontal: 40, vertical: 14),
+                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                backgroundColor: Colors.teal,
               ),
-              child: Text(
-                '확인',
-                style: TextStyle(
-                  fontSize: 18,
-                  color: Colors.black,
-                  fontFamily: 'MPlusRounded1c',
-                ),
-              ),
-            ),
-            SizedBox(height: 30),
-            Text(
-              resultText,
-              style: TextStyle(
-                fontSize: 24,
-                fontWeight: FontWeight.bold,
-                fontFamily: 'MPlusRounded1c',
-                color: resultText == 'Correct!!' ? Colors.green : Colors.red,
-              ),
+              child: const Text('제출하기', style: TextStyle(fontSize: 18)),
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildLetterBox(String letter, {bool isRevealed = false}) {
+    return Container(
+      width: 48,
+      height: 48,
+      margin: const EdgeInsets.symmetric(horizontal: 4),
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: isRevealed ? Colors.grey[300] : Colors.white,
+        border: Border.all(color: Colors.black54),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        letter,
+        style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+      ),
+    );
+  }
+
+  Widget _buildInputBox(int index) {
+    return Container(
+      width: 48,
+      height: 48,
+      margin: const EdgeInsets.symmetric(horizontal: 4),
+      child: TextField(
+        controller: controllers[index],
+        maxLength: 1,
+        textAlign: TextAlign.center,
+        style: const TextStyle(fontSize: 24),
+        decoration: const InputDecoration(
+          counterText: '',
+          border: OutlineInputBorder(),
+        ),
+        onChanged: (value) {
+          if (value.length > 1) {
+            controllers[index].text = value[0];
+          }
+          setState(() {
+            userInput[index] = value;
+          });
+        },
       ),
     );
   }

--- a/mobidic_flutter/lib/Fill_blank.dart
+++ b/mobidic_flutter/lib/Fill_blank.dart
@@ -7,7 +7,7 @@ class FillBlankPage extends StatefulWidget {
   State<FillBlankPage> createState() => _FillBlankPageState();
 }
 
-class _FillBlankPageState extends State<FillBlankPage> {    //리스트
+class _FillBlankPageState extends State<FillBlankPage> {
   final List<Map<String, dynamic>> quizList = [
     {
       'word': 'apple',
@@ -29,6 +29,8 @@ class _FillBlankPageState extends State<FillBlankPage> {    //리스트
   int currentIndex = 0;
   List<String> userInput = [];
   List<TextEditingController> controllers = [];
+  int totalAttempts = 0;
+  int correctAnswers = 0;
 
   @override
   void initState() {
@@ -52,48 +54,42 @@ class _FillBlankPageState extends State<FillBlankPage> {    //리스트
 
     String answer = '';
     for (int i = 0; i < word.length; i++) {
-      answer += revealed[i] ? word[i] : (userInput[i].toLowerCase());
+      answer += revealed[i] ? word[i] : userInput[i].toLowerCase();
     }
 
-    if (answer == word) {
-      showDialog(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text('정답입니다!! 🎉'),
-          actions: [
-            TextButton(
-              onPressed: () {
-                Navigator.pop(context);
-                setState(() {
-                  if (currentIndex < quizList.length - 1) {
-                    currentIndex++;
-                    _setupCurrentQuestion();
-                  } else {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text("퀴즈 완료!")),
-                    );
-                  }
-                });
-              },
-              child: const Text("다음 문제"),
-            )
-          ],
-        ),
-      );
-    } else {
-      showDialog(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text('다시 생각해보세요. 😢'),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text('확인'),
-            )
-          ],
-        ),
-      );
-    }
+    bool isCorrect = answer == word;
+
+    setState(() {
+      totalAttempts++;
+      if (isCorrect) correctAnswers++;
+    });
+
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: Text(isCorrect ? '정답입니다!! 🎉' : '오답입니다. 😢'),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.pop(context);
+              setState(() {
+                if (currentIndex < quizList.length - 1) {
+                  currentIndex++;
+                  _setupCurrentQuestion();
+                }
+              });
+            },
+            child: const Text("다음 문제"),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String getAccuracyText() {
+    if (totalAttempts == 0) return "정답률: 0%";
+    double percent = (correctAnswers / totalAttempts) * 100;
+    return "정답률: ${percent.toStringAsFixed(1)}% ($correctAnswers / $totalAttempts)";
   }
 
   @override
@@ -115,35 +111,88 @@ class _FillBlankPageState extends State<FillBlankPage> {    //리스트
       appBar: AppBar(
         title: const Text('빈칸 채우기'),
         centerTitle: true,
-        backgroundColor: Colors.teal,
+        backgroundColor: Colors.blue,
+        foregroundColor: Colors.white,
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(32.0),
-        child: Column(
-          children: [
-            const SizedBox(height: 40),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: List.generate(word.length, (i) {
-                if (revealed[i]) {
-                  return _buildLetterBox(word[i], isRevealed: true);
-                } else {
-                  return _buildInputBox(i);
-                }
-              }),
-            ),
-            const SizedBox(height: 40),
-            Text('뜻: $meaning', style: const TextStyle(fontSize: 20)),
-            const SizedBox(height: 40),
-            ElevatedButton(
-              onPressed: checkAnswer,
-              style: ElevatedButton.styleFrom(
-                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-                backgroundColor: Colors.teal,
+      body: Container(
+        width: double.infinity,
+        height: double.infinity,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              Color(0xFFb2ebf2),
+              Color(0xFF81d4fa),
+              Color(0xFF4fc3f7),
+            ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(32.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Align(
+                alignment: Alignment.centerRight,
+                child: Text(
+                  getAccuracyText(),
+                  style: const TextStyle(fontSize: 16, color: Colors.grey),
+                ),
               ),
-              child: const Text('제출하기', style: TextStyle(fontSize: 18)),
-            ),
-          ],
+              const SizedBox(height: 40),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: List.generate(word.length, (i) {
+                  if (revealed[i]) {
+                    return _buildLetterBox(word[i], isRevealed: true);
+                  } else {
+                    return _buildInputBox(i);
+                  }
+                }),
+              ),
+              const SizedBox(height: 40),
+              Text('뜻: $meaning', style: const TextStyle(fontSize: 20)),
+              const SizedBox(height: 40),
+              Center(
+                child: ElevatedButton(
+                  onPressed: checkAnswer,
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                    backgroundColor: Colors.blue,
+                    foregroundColor: Colors.white,
+                  ),
+                  child: const Text('제출하기', style: TextStyle(fontSize: 18)),
+                ),
+              ),
+              if (currentIndex == quizList.length - 1 &&
+                  totalAttempts == quizList.length)
+                const Padding(
+                  padding: EdgeInsets.only(top: 20),
+                  child: Center(
+                    child: Text(
+                      "🎉 퀴즈 완료!",
+                      style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                ),
+              const SizedBox(height: 40),
+            ],
+          ),
+        ),
+      ),
+      bottomNavigationBar: BottomAppBar(
+        color: Colors.grey[300],
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: const [
+              Icon(Icons.note, color: Colors.black),
+              Icon(Icons.home, color: Colors.black),
+              Icon(Icons.exit_to_app, color: Colors.black),
+            ],
+          ),
         ),
       ),
     );
@@ -156,7 +205,7 @@ class _FillBlankPageState extends State<FillBlankPage> {    //리스트
       margin: const EdgeInsets.symmetric(horizontal: 4),
       alignment: Alignment.center,
       decoration: BoxDecoration(
-        color: isRevealed ? Colors.grey[300] : Colors.white,
+        color: isRevealed ? Colors.lightBlue[100] : Colors.white,
         border: Border.all(color: Colors.black54),
         borderRadius: BorderRadius.circular(8),
       ),

--- a/mobidic_flutter/lib/Log_in_page.dart
+++ b/mobidic_flutter/lib/Log_in_page.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-//import 'Find_id_pw.dart';
 
-// 로그인 페이지
 class LoginPage extends StatefulWidget {
   @override
   State<LoginPage> createState() => _LoginPageState();
@@ -12,7 +10,6 @@ class _LoginPageState extends State<LoginPage> {
   final TextEditingController passwordController = TextEditingController();
   bool isLoading = false;
 
-  // 로그인 함수
   void handleLogin() async {
     setState(() => isLoading = true);
     await Future.delayed(Duration(seconds: 2));
@@ -26,18 +23,18 @@ class _LoginPageState extends State<LoginPage> {
         builder: (_) => AlertDialog(
           title: Text(
             '\u2705 로그인 성공',
-            style: TextStyle(fontFamily: 'Baloo2'), // 앱 제목 폰트
+            style: TextStyle(fontFamily: 'Baloo2'),
           ),
           content: Text(
             '환영합니다, $email 님!',
-            style: TextStyle(fontFamily: 'MPlusRounded1c'), // 본문 폰트
+            style: TextStyle(fontFamily: 'MPlusRounded1c'),
           ),
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(context),
               child: Text(
                 '확인',
-                style: TextStyle(fontFamily: 'Quicksand'), // 버튼 폰트
+                style: TextStyle(fontFamily: 'Quicksand'),
               ),
             ),
           ],
@@ -49,24 +46,25 @@ class _LoginPageState extends State<LoginPage> {
         builder: (_) => AlertDialog(
           title: Text(
             '\u274C 로그인 실패',
-            style: TextStyle(fontFamily: 'Baloo2'), // 앱 제목 폰트
+            style: TextStyle(fontFamily: 'Baloo2'),
           ),
           content: Text(
             '아이디 또는 비밀번호가 잘못되었습니다.',
-            style: TextStyle(fontFamily: 'MPlusRounded1c'), // 본문 폰트
+            style: TextStyle(fontFamily: 'MPlusRounded1c'),
           ),
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(context),
               child: Text(
                 '다시 시도',
-                style: TextStyle(fontFamily: 'Quicksand'), // 버튼 폰트
+                style: TextStyle(fontFamily: 'Quicksand'),
               ),
             ),
           ],
         ),
       );
     }
+
     setState(() => isLoading = false);
   }
 
@@ -87,70 +85,105 @@ class _LoginPageState extends State<LoginPage> {
             padding: const EdgeInsets.all(24.0),
             child: Column(
               children: [
-                Image.asset('assets/whale.png', height: 150), // 로고 이미지
-                SizedBox(height: 30),
+                Image.asset('assets/whale.png', height: 150),
+                const SizedBox(height: 30),
                 TextField(
                   controller: emailController,
                   decoration: InputDecoration(
                     labelText: 'Login ID',
-                    prefixIcon: Icon(Icons.person),
-                    border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                    prefixIcon: const Icon(Icons.person),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
                   ),
-                  style: TextStyle(fontFamily: 'MPlusRounded1c'), // 본문 폰트
+                  style: const TextStyle(fontFamily: 'MPlusRounded1c'),
                 ),
-                SizedBox(height: 20),
+                const SizedBox(height: 20),
                 TextField(
                   controller: passwordController,
                   obscureText: true,
                   decoration: InputDecoration(
                     labelText: 'Password',
-                    prefixIcon: Icon(Icons.lock),
-                    border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                    prefixIcon: const Icon(Icons.lock),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
                   ),
-                  style: TextStyle(fontFamily: 'MPlusRounded1c'), // 본문 폰트
+                  style: const TextStyle(fontFamily: 'MPlusRounded1c'),
                 ),
-                SizedBox(height: 20),
+                const SizedBox(height: 20),
                 Align(
                   alignment: Alignment.centerRight,
                   child: TextButton(
                     onPressed: () {
                       Navigator.pushNamed(context, '/find');
                     },
-                    child: Text(
+                    child: const Text(
                       '아이디/비밀번호 찾기',
-                      style: TextStyle(fontFamily: 'Quicksand'), // 버튼 텍스트 폰트
+                      style: TextStyle(fontFamily: 'Quicksand'),
                     ),
                   ),
                 ),
-                SizedBox(height: 10),
+                const SizedBox(height: 10),
                 AnimatedContainer(
-                  duration: Duration(milliseconds: 300),
+                  duration: const Duration(milliseconds: 300),
                   width: double.infinity,
                   height: 50,
                   child: ElevatedButton(
                     onPressed: isLoading ? null : handleLogin,
                     style: ElevatedButton.styleFrom(
                       backgroundColor: Colors.blue.shade700,
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                      textStyle: TextStyle(fontFamily: 'Quicksand'), // 버튼 폰트
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      textStyle: const TextStyle(fontFamily: 'Quicksand'),
                     ),
                     child: isLoading
-                        ? CircularProgressIndicator(valueColor: AlwaysStoppedAnimation<Color>(Colors.white))
-                        : Text('Login', style: TextStyle(fontSize: 18)),
+                        ? const CircularProgressIndicator(
+                      valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                    )
+                        : const Text(
+                      'Login',
+                      style: TextStyle(
+                        fontSize: 18,
+                        color: Colors.white,
+                        fontFamily: 'Quicksand',
+                      ),
+                    ),
                   ),
                 ),
-                SizedBox(height: 20),
+                const SizedBox(height: 20),
                 OutlinedButton(
                   onPressed: () => Navigator.pushNamed(context, '/signup'),
                   style: OutlinedButton.styleFrom(
                     side: BorderSide(color: Colors.blue.shade700),
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                    textStyle: TextStyle(fontFamily: 'Quicksand'), // 버튼 폰트
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    textStyle: const TextStyle(fontFamily: 'Quicksand'),
                   ),
-                  child: Text('회원가입', style: TextStyle(fontSize: 16)),
+                  child: const Text(
+                    '회원가입',
+                    style: TextStyle(fontSize: 16),
+                  ),
                 ),
+                const SizedBox(height: 40), // 하단바를 가릴 여유 공간
               ],
             ),
+          ),
+        ),
+      ),
+      bottomNavigationBar: BottomAppBar(
+        color: Colors.grey[300],
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: const [
+              Icon(Icons.note, color: Colors.black),
+              Icon(Icons.home, color: Colors.black),
+              Icon(Icons.exit_to_app, color: Colors.black),
+            ],
           ),
         ),
       ),

--- a/mobidic_flutter/lib/Log_in_page.dart
+++ b/mobidic_flutter/lib/Log_in_page.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+//import 'Find_id_pw.dart';
+
+// 로그인 페이지
+class LoginPage extends StatefulWidget {
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final TextEditingController emailController = TextEditingController();
+  final TextEditingController passwordController = TextEditingController();
+  bool isLoading = false;
+
+  // 로그인 함수
+  void handleLogin() async {
+    setState(() => isLoading = true);
+    await Future.delayed(Duration(seconds: 2));
+
+    final email = emailController.text;
+    final password = passwordController.text;
+
+    if (email == 'testid' && password == 'testpassword') {
+      showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: Text(
+            '\u2705 로그인 성공',
+            style: TextStyle(fontFamily: 'Baloo2'), // 앱 제목 폰트
+          ),
+          content: Text(
+            '환영합니다, $email 님!',
+            style: TextStyle(fontFamily: 'MPlusRounded1c'), // 본문 폰트
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(
+                '확인',
+                style: TextStyle(fontFamily: 'Quicksand'), // 버튼 폰트
+              ),
+            ),
+          ],
+        ),
+      );
+    } else {
+      showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: Text(
+            '\u274C 로그인 실패',
+            style: TextStyle(fontFamily: 'Baloo2'), // 앱 제목 폰트
+          ),
+          content: Text(
+            '아이디 또는 비밀번호가 잘못되었습니다.',
+            style: TextStyle(fontFamily: 'MPlusRounded1c'), // 본문 폰트
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(
+                '다시 시도',
+                style: TextStyle(fontFamily: 'Quicksand'), // 버튼 폰트
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+    setState(() => isLoading = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        width: double.infinity,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFFb2ebf2), Color(0xFF81d4fa), Color(0xFF4fc3f7)],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24.0),
+            child: Column(
+              children: [
+                Image.asset('assets/whale.png', height: 150), // 로고 이미지
+                SizedBox(height: 30),
+                TextField(
+                  controller: emailController,
+                  decoration: InputDecoration(
+                    labelText: 'Login ID',
+                    prefixIcon: Icon(Icons.person),
+                    border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                  ),
+                  style: TextStyle(fontFamily: 'MPlusRounded1c'), // 본문 폰트
+                ),
+                SizedBox(height: 20),
+                TextField(
+                  controller: passwordController,
+                  obscureText: true,
+                  decoration: InputDecoration(
+                    labelText: 'Password',
+                    prefixIcon: Icon(Icons.lock),
+                    border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                  ),
+                  style: TextStyle(fontFamily: 'MPlusRounded1c'), // 본문 폰트
+                ),
+                SizedBox(height: 20),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton(
+                    onPressed: () {
+                      Navigator.pushNamed(context, '/find');
+                    },
+                    child: Text(
+                      '아이디/비밀번호 찾기',
+                      style: TextStyle(fontFamily: 'Quicksand'), // 버튼 텍스트 폰트
+                    ),
+                  ),
+                ),
+                SizedBox(height: 10),
+                AnimatedContainer(
+                  duration: Duration(milliseconds: 300),
+                  width: double.infinity,
+                  height: 50,
+                  child: ElevatedButton(
+                    onPressed: isLoading ? null : handleLogin,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.blue.shade700,
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                      textStyle: TextStyle(fontFamily: 'Quicksand'), // 버튼 폰트
+                    ),
+                    child: isLoading
+                        ? CircularProgressIndicator(valueColor: AlwaysStoppedAnimation<Color>(Colors.white))
+                        : Text('Login', style: TextStyle(fontSize: 18)),
+                  ),
+                ),
+                SizedBox(height: 20),
+                OutlinedButton(
+                  onPressed: () => Navigator.pushNamed(context, '/signup'),
+                  style: OutlinedButton.styleFrom(
+                    side: BorderSide(color: Colors.blue.shade700),
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                    textStyle: TextStyle(fontFamily: 'Quicksand'), // 버튼 폰트
+                  ),
+                  child: Text('회원가입', style: TextStyle(fontSize: 16)),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobidic_flutter/lib/OX_Quiz.dart
+++ b/mobidic_flutter/lib/OX_Quiz.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class OXQuizPage extends StatefulWidget {
-  const OXQuizPage({super.key}); // 라우터용 const 생성자
+  const OXQuizPage({super.key});
 
   @override
   State<OXQuizPage> createState() => _OXQuizPageState();
@@ -15,48 +15,47 @@ class _OXQuizPageState extends State<OXQuizPage> {
   ];
 
   int currentIndex = 0;
+  int correctAnswers = 0;
+  int totalAttempts = 0;
 
   void _checkAnswer(bool userAnswer) {
     bool correctAnswer = quizList[currentIndex]['isCorrect'];
+    bool isCorrect = userAnswer == correctAnswer;
 
-    if (userAnswer == correctAnswer) {
-      showDialog(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text("정답입니다!! 🎉"),
-          actions: [
-            TextButton(
-              onPressed: () {
-                Navigator.pop(context);
-                setState(() {
-                  if (currentIndex < quizList.length - 1) {
-                    currentIndex++;
-                  } else {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text("퀴즈 완료!")),
-                    );
-                  }
-                });
-              },
-              child: const Text("다음 문제"),
-            )
-          ],
-        ),
-      );
-    } else {
-      showDialog(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text("다시 생각해보세요 ㅠ"),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text("확인"),
-            )
-          ],
-        ),
-      );
-    }
+    setState(() {
+      totalAttempts++;
+      if (isCorrect) correctAnswers++;
+    });
+
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: Text(isCorrect ? "정답입니다!! 🎉" : "오답입니다. 😢"),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.pop(context);
+              setState(() {
+                if (currentIndex < quizList.length - 1) {
+                  currentIndex++;
+                } else {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text("퀴즈 완료!")),
+                  );
+                }
+              });
+            },
+            child: const Text("다음 문제"),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String getAccuracyText() {
+    if (totalAttempts == 0) return "정답률: 0%";
+    double percent = (correctAnswers / totalAttempts) * 100;
+    return "정답률: ${percent.toStringAsFixed(1)}% ($correctAnswers / $totalAttempts)";
   }
 
   @override
@@ -67,45 +66,97 @@ class _OXQuizPageState extends State<OXQuizPage> {
       appBar: AppBar(
         title: const Text('O X 퀴즈'),
         centerTitle: true,
-        backgroundColor: Colors.deepPurple,
+        backgroundColor: Colors.blue,
         foregroundColor: Colors.white,
       ),
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 48),
-        child: Column(
-          children: [
-            Text(
-              currentQuiz['word'],
-              style: const TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 12),
-            Text(
-              currentQuiz['meaning'],
-              style: const TextStyle(fontSize: 24, color: Colors.grey),
-            ),
-            const SizedBox(height: 60),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                ElevatedButton(
-                  onPressed: () => _checkAnswer(true),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.green,
-                    padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
-                  ),
-                  child: const Text('O', style: TextStyle(fontSize: 24)),
+      body: Container(
+        width: double.infinity,
+        height: double.infinity,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              Color(0xFFb2ebf2),
+              Color(0xFF81d4fa),
+              Color(0xFF4fc3f7),
+            ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 48),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Align(
+                alignment: Alignment.centerRight,
+                child: Text(
+                  getAccuracyText(),
+                  style: const TextStyle(fontSize: 16, color: Colors.grey),
                 ),
-                ElevatedButton(
-                  onPressed: () => _checkAnswer(false),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.red,
-                    padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
-                  ),
-                  child: const Text('X', style: TextStyle(fontSize: 24)),
+              ),
+              const SizedBox(height: 40),
+              Center(
+                child: Column(
+                  children: [
+                    Text(
+                      currentQuiz['word'],
+                      style: const TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      currentQuiz['meaning'],
+                      style: const TextStyle(fontSize: 24, color: Colors.grey),
+                    ),
+                  ],
                 ),
-              ],
-            )
-          ],
+              ),
+              const SizedBox(height: 60),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  ElevatedButton(
+                    onPressed: () => _checkAnswer(true),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.green,
+                      padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
+                    ),
+                    child: const Text('O', style: TextStyle(fontSize: 24)),
+                  ),
+                  ElevatedButton(
+                    onPressed: () => _checkAnswer(false),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.red,
+                      padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
+                    ),
+                    child: const Text('X', style: TextStyle(fontSize: 24)),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 40),
+              if (currentIndex == quizList.length - 1 && totalAttempts == quizList.length)
+                const Center(
+                  child: Text(
+                    "🎉 퀴즈 완료!",
+                    style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+      bottomNavigationBar: BottomAppBar(
+        color: Colors.grey[300],
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: const [
+              Icon(Icons.note, color: Colors.black),
+              Icon(Icons.home, color: Colors.black),
+              Icon(Icons.exit_to_app, color: Colors.black),
+            ],
+          ),
         ),
       ),
     );

--- a/mobidic_flutter/lib/OX_Quiz.dart
+++ b/mobidic_flutter/lib/OX_Quiz.dart
@@ -1,110 +1,110 @@
 import 'package:flutter/material.dart';
 
-class OxQuizPage extends StatelessWidget {
+class OXQuizPage extends StatefulWidget {
+  const OXQuizPage({super.key}); // 라우터용 const 생성자
+
+  @override
+  State<OXQuizPage> createState() => _OXQuizPageState();
+}
+
+class _OXQuizPageState extends State<OXQuizPage> {
+  final List<Map<String, dynamic>> quizList = [
+    {'word': 'Apple', 'meaning': '사과', 'isCorrect': true},
+    {'word': 'Dog', 'meaning': '고양이', 'isCorrect': false},
+    {'word': 'Car', 'meaning': '자동차', 'isCorrect': true},
+  ];
+
+  int currentIndex = 0;
+
+  void _checkAnswer(bool userAnswer) {
+    bool correctAnswer = quizList[currentIndex]['isCorrect'];
+
+    if (userAnswer == correctAnswer) {
+      showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text("정답입니다!! 🎉"),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context);
+                setState(() {
+                  if (currentIndex < quizList.length - 1) {
+                    currentIndex++;
+                  } else {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text("퀴즈 완료!")),
+                    );
+                  }
+                });
+              },
+              child: const Text("다음 문제"),
+            )
+          ],
+        ),
+      );
+    } else {
+      showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text("다시 생각해보세요 ㅠ"),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text("확인"),
+            )
+          ],
+        ),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
+    final currentQuiz = quizList[currentIndex];
+
     return Scaffold(
-      backgroundColor: Colors.lightBlue.shade100, // 배경 파란색
-      body: SafeArea(
+      appBar: AppBar(
+        title: const Text('O X 퀴즈'),
+        centerTitle: true,
+        backgroundColor: Colors.deepPurple,
+        foregroundColor: Colors.white,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 48),
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            SizedBox(height: 20),
             Text(
-              'O,X Quiz',
-              style: TextStyle(
-                fontSize: 28,
-                fontFamily: 'Baloo2',
-                fontWeight: FontWeight.bold,
-              ),
+              currentQuiz['word'],
+              style: const TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
             ),
-            SizedBox(height: 20),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Row(
-                children: [
-                  IconButton(
-                    icon: Icon(Icons.arrow_back),
-                    onPressed: () {
-                      Navigator.pop(context); // 뒤로가기
-                    },
-                  ),
-                  Text(
-                    'O,X Quiz',
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontFamily: 'MPlusRounded1c',
-                    ),
-                  ),
-                  Spacer(),
-                  IconButton(
-                    icon: Icon(Icons.home),
-                    onPressed: () {
-                      // 홈 이동 기능 나중에 추가
-                    },
-                  ),
-                ],
-              ),
-            ),
-            SizedBox(height: 60),
+            const SizedBox(height: 12),
             Text(
-              'Apple',
-              style: TextStyle(
-                fontSize: 32,
-                fontFamily: 'MPlusRounded1c',
-                fontWeight: FontWeight.bold,
-              ),
+              currentQuiz['meaning'],
+              style: const TextStyle(fontSize: 24, color: Colors.grey),
             ),
-            SizedBox(height: 60),
-            Container(
-              margin: EdgeInsets.symmetric(horizontal: 32),
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: () {
-                  // '사과' 버튼 기능 (나중에 추가)
-                },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.white,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(30),
+            const SizedBox(height: 60),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                ElevatedButton(
+                  onPressed: () => _checkAnswer(true),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.green,
+                    padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
                   ),
-                  padding: EdgeInsets.symmetric(vertical: 16),
+                  child: const Text('O', style: TextStyle(fontSize: 24)),
                 ),
-                child: Text(
-                  '사과',
-                  style: TextStyle(
-                    fontSize: 20,
-                    color: Colors.black,
-                    fontFamily: 'MPlusRounded1c',
+                ElevatedButton(
+                  onPressed: () => _checkAnswer(false),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.red,
+                    padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
                   ),
+                  child: const Text('X', style: TextStyle(fontSize: 24)),
                 ),
-              ),
-            ),
-            SizedBox(height: 20),
-            Container(
-              margin: EdgeInsets.symmetric(horizontal: 32),
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: () {
-                  // '배' 버튼 기능 (나중에 추가)
-                },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.white,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(30),
-                  ),
-                  padding: EdgeInsets.symmetric(vertical: 16),
-                ),
-                child: Text(
-                  '배',
-                  style: TextStyle(
-                    fontSize: 20,
-                    color: Colors.black,
-                    fontFamily: 'MPlusRounded1c',
-                  ),
-                ),
-              ),
-            ),
+              ],
+            )
           ],
         ),
       ),

--- a/mobidic_flutter/lib/Sign_up_page.dart
+++ b/mobidic_flutter/lib/Sign_up_page.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/material.dart';
+
+class SignUpPage extends StatefulWidget {
+  @override
+  _SignUpPageState createState() => _SignUpPageState();
+}
+
+class _SignUpPageState extends State<SignUpPage> {
+  final TextEditingController newIdController = TextEditingController();
+  final TextEditingController newPasswordController = TextEditingController();
+  final TextEditingController confirmPasswordController = TextEditingController();
+
+  String? emailErrorText;
+  String? passwordErrorText;
+  String? confirmPasswordErrorText;
+
+  bool isPasswordVisible = false;
+  bool isConfirmPasswordVisible = false;
+
+  bool isValidEmail(String email) {
+    final regex = RegExp(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$");
+    return regex.hasMatch(email);
+  }
+
+  bool isValidPassword(String password) {
+    if (password.length < 8) return false;
+    final forbiddenChars = RegExp(r'[-=]');
+    final specialCharRegex = RegExp(r'''[!@#\$%^&*()_+{}\[\]:;"'<>,.?/\\|`~]''');
+
+    if (forbiddenChars.hasMatch(password)) return false;
+    if (!specialCharRegex.hasMatch(password)) return false;
+
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          '회원가입',
+          style: TextStyle(
+            // fontFamily: 'Baloo2', // 앱 제목 폰트
+            fontSize: 24,
+          ),
+        ),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: newIdController,
+              decoration: InputDecoration(
+                labelText: '이메일 (example@naver.com)',
+                helperText: '올바른 이메일 형식을 입력하세요.',
+                errorText: emailErrorText,
+                border: OutlineInputBorder(),
+              ),
+              style: TextStyle(
+                // fontFamily: 'MPlusRounded1c', // 본문 폰트
+              ),
+            ),
+            SizedBox(height: 20),
+            TextField(
+              controller: newPasswordController,
+              obscureText: !isPasswordVisible,
+              decoration: InputDecoration(
+                labelText: '비밀번호',
+                helperText: '8자 이상 + 특수문자 1개 이상 ( - 와 = 제외 )',
+                errorText: passwordErrorText,
+                border: OutlineInputBorder(),
+                suffixIcon: IconButton(
+                  icon: Icon(
+                    isPasswordVisible ? Icons.visibility : Icons.visibility_off,
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      isPasswordVisible = !isPasswordVisible;
+                    });
+                  },
+                ),
+              ),
+              style: TextStyle(
+                //  fontFamily: 'MPlusRounded1c', // 본문 폰트
+              ),
+            ),
+            SizedBox(height: 20),
+            TextField(
+              controller: confirmPasswordController,
+              obscureText: !isConfirmPasswordVisible,
+              decoration: InputDecoration(
+                labelText: '비밀번호 확인',
+                errorText: confirmPasswordErrorText,
+                border: OutlineInputBorder(),
+                suffixIcon: IconButton(
+                  icon: Icon(
+                    isConfirmPasswordVisible ? Icons.visibility : Icons.visibility_off,
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      isConfirmPasswordVisible = !isConfirmPasswordVisible;
+                    });
+                  },
+                ),
+              ),
+              style: TextStyle(
+                //fontFamily: 'MPlusRounded1c', // 본문 폰트
+              ),
+            ),
+            SizedBox(height: 30),
+            ElevatedButton(
+              onPressed: () {
+                final id = newIdController.text.trim();
+                final pass = newPasswordController.text;
+                final confirm = confirmPasswordController.text;
+
+                setState(() {
+                  emailErrorText = null;
+                  passwordErrorText = null;
+                  confirmPasswordErrorText = null;
+                });
+
+                bool hasError = false;
+
+                if (!isValidEmail(id)) {
+                  setState(() {
+                    emailErrorText = '올바른 이메일을 입력해주세요.';
+                  });
+                  hasError = true;
+                }
+
+                if (!isValidPassword(pass)) {
+                  setState(() {
+                    passwordErrorText = '비밀번호는 8자 이상, 특수문자 포함해야 하며 (-, =) 금지입니다.';
+                  });
+                  hasError = true;
+                }
+
+                if (pass != confirm) {
+                  setState(() {
+                    confirmPasswordErrorText = '비밀번호가 일치하지 않습니다.';
+                  });
+                  hasError = true;
+                }
+
+                if (hasError) {
+                  return;
+                }
+
+                showDialog(
+                  context: context,
+                  builder: (_) => AlertDialog(
+                    title: Text(
+                      '알림',
+                      // style: TextStyle(fontFamily: 'Baloo2'),
+                    ),
+                    content: Text(
+                      '회원가입이 완료되었습니다!',
+                      //  style: TextStyle(fontFamily: 'MPlusRounded1c'),
+                    ),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(context),
+                        child: Text(
+                          '확인',
+                          // style: TextStyle(fontFamily: 'Quicksand'), // 버튼 폰트
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+              style: ElevatedButton.styleFrom(
+                // textStyle: TextStyle(fontFamily: 'Quicksand'), // 버튼 폰트
+              ),
+              child: Text('회원가입'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobidic_flutter/lib/Sign_up_page.dart
+++ b/mobidic_flutter/lib/Sign_up_page.dart
@@ -37,146 +37,150 @@ class _SignUpPageState extends State<SignUpPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(
+        title: const Text(
           '회원가입',
-          style: TextStyle(
-            // fontFamily: 'Baloo2', // 앱 제목 폰트
-            fontSize: 24,
+          style: TextStyle(fontSize: 24),
+        ),
+      ),
+      body: Container(
+        width: double.infinity,
+        height: double.infinity,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              Color(0xFFb2ebf2),
+              Color(0xFF81d4fa),
+              Color(0xFF4fc3f7),
+            ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            children: [
+              TextField(
+                controller: newIdController,
+                decoration: InputDecoration(
+                  labelText: '이메일 (example@naver.com)',
+                  helperText: '올바른 이메일 형식을 입력하세요.',
+                  errorText: emailErrorText,
+                  border: const OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 20),
+              TextField(
+                controller: newPasswordController,
+                obscureText: !isPasswordVisible,
+                decoration: InputDecoration(
+                  labelText: '비밀번호',
+                  helperText: '8자 이상 + 특수문자 1개 이상 ( - 와 = 제외 )',
+                  errorText: passwordErrorText,
+                  border: const OutlineInputBorder(),
+                  suffixIcon: IconButton(
+                    icon: Icon(
+                      isPasswordVisible ? Icons.visibility : Icons.visibility_off,
+                    ),
+                    onPressed: () {
+                      setState(() {
+                        isPasswordVisible = !isPasswordVisible;
+                      });
+                    },
+                  ),
+                ),
+              ),
+              const SizedBox(height: 20),
+              TextField(
+                controller: confirmPasswordController,
+                obscureText: !isConfirmPasswordVisible,
+                decoration: InputDecoration(
+                  labelText: '비밀번호 확인',
+                  errorText: confirmPasswordErrorText,
+                  border: const OutlineInputBorder(),
+                  suffixIcon: IconButton(
+                    icon: Icon(
+                      isConfirmPasswordVisible ? Icons.visibility : Icons.visibility_off,
+                    ),
+                    onPressed: () {
+                      setState(() {
+                        isConfirmPasswordVisible = !isConfirmPasswordVisible;
+                      });
+                    },
+                  ),
+                ),
+              ),
+              const SizedBox(height: 30),
+              ElevatedButton(
+                onPressed: () {
+                  final id = newIdController.text.trim();
+                  final pass = newPasswordController.text;
+                  final confirm = confirmPasswordController.text;
+
+                  setState(() {
+                    emailErrorText = null;
+                    passwordErrorText = null;
+                    confirmPasswordErrorText = null;
+                  });
+
+                  bool hasError = false;
+
+                  if (!isValidEmail(id)) {
+                    setState(() {
+                      emailErrorText = '올바른 이메일을 입력해주세요.';
+                    });
+                    hasError = true;
+                  }
+
+                  if (!isValidPassword(pass)) {
+                    setState(() {
+                      passwordErrorText = '비밀번호는 8자 이상, 특수문자 포함해야 하며 (-, =) 금지입니다.';
+                    });
+                    hasError = true;
+                  }
+
+                  if (pass != confirm) {
+                    setState(() {
+                      confirmPasswordErrorText = '비밀번호가 일치하지 않습니다.';
+                    });
+                    hasError = true;
+                  }
+
+                  if (hasError) return;
+
+                  showDialog(
+                    context: context,
+                    builder: (_) => AlertDialog(
+                      title: const Text('알림'),
+                      content: const Text('회원가입이 완료되었습니다!'),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(context),
+                          child: const Text('확인'),
+                        ),
+                      ],
+                    ),
+                  );
+                },
+                child: const Text('회원가입'),
+              ),
+              const SizedBox(height: 40),
+            ],
           ),
         ),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(24.0),
-        child: Column(
-          children: [
-            TextField(
-              controller: newIdController,
-              decoration: InputDecoration(
-                labelText: '이메일 (example@naver.com)',
-                helperText: '올바른 이메일 형식을 입력하세요.',
-                errorText: emailErrorText,
-                border: OutlineInputBorder(),
-              ),
-              style: TextStyle(
-                // fontFamily: 'MPlusRounded1c', // 본문 폰트
-              ),
-            ),
-            SizedBox(height: 20),
-            TextField(
-              controller: newPasswordController,
-              obscureText: !isPasswordVisible,
-              decoration: InputDecoration(
-                labelText: '비밀번호',
-                helperText: '8자 이상 + 특수문자 1개 이상 ( - 와 = 제외 )',
-                errorText: passwordErrorText,
-                border: OutlineInputBorder(),
-                suffixIcon: IconButton(
-                  icon: Icon(
-                    isPasswordVisible ? Icons.visibility : Icons.visibility_off,
-                  ),
-                  onPressed: () {
-                    setState(() {
-                      isPasswordVisible = !isPasswordVisible;
-                    });
-                  },
-                ),
-              ),
-              style: TextStyle(
-                //  fontFamily: 'MPlusRounded1c', // 본문 폰트
-              ),
-            ),
-            SizedBox(height: 20),
-            TextField(
-              controller: confirmPasswordController,
-              obscureText: !isConfirmPasswordVisible,
-              decoration: InputDecoration(
-                labelText: '비밀번호 확인',
-                errorText: confirmPasswordErrorText,
-                border: OutlineInputBorder(),
-                suffixIcon: IconButton(
-                  icon: Icon(
-                    isConfirmPasswordVisible ? Icons.visibility : Icons.visibility_off,
-                  ),
-                  onPressed: () {
-                    setState(() {
-                      isConfirmPasswordVisible = !isConfirmPasswordVisible;
-                    });
-                  },
-                ),
-              ),
-              style: TextStyle(
-                //fontFamily: 'MPlusRounded1c', // 본문 폰트
-              ),
-            ),
-            SizedBox(height: 30),
-            ElevatedButton(
-              onPressed: () {
-                final id = newIdController.text.trim();
-                final pass = newPasswordController.text;
-                final confirm = confirmPasswordController.text;
-
-                setState(() {
-                  emailErrorText = null;
-                  passwordErrorText = null;
-                  confirmPasswordErrorText = null;
-                });
-
-                bool hasError = false;
-
-                if (!isValidEmail(id)) {
-                  setState(() {
-                    emailErrorText = '올바른 이메일을 입력해주세요.';
-                  });
-                  hasError = true;
-                }
-
-                if (!isValidPassword(pass)) {
-                  setState(() {
-                    passwordErrorText = '비밀번호는 8자 이상, 특수문자 포함해야 하며 (-, =) 금지입니다.';
-                  });
-                  hasError = true;
-                }
-
-                if (pass != confirm) {
-                  setState(() {
-                    confirmPasswordErrorText = '비밀번호가 일치하지 않습니다.';
-                  });
-                  hasError = true;
-                }
-
-                if (hasError) {
-                  return;
-                }
-
-                showDialog(
-                  context: context,
-                  builder: (_) => AlertDialog(
-                    title: Text(
-                      '알림',
-                      // style: TextStyle(fontFamily: 'Baloo2'),
-                    ),
-                    content: Text(
-                      '회원가입이 완료되었습니다!',
-                      //  style: TextStyle(fontFamily: 'MPlusRounded1c'),
-                    ),
-                    actions: [
-                      TextButton(
-                        onPressed: () => Navigator.pop(context),
-                        child: Text(
-                          '확인',
-                          // style: TextStyle(fontFamily: 'Quicksand'), // 버튼 폰트
-                        ),
-                      ),
-                    ],
-                  ),
-                );
-              },
-              style: ElevatedButton.styleFrom(
-                // textStyle: TextStyle(fontFamily: 'Quicksand'), // 버튼 폰트
-              ),
-              child: Text('회원가입'),
-            ),
-          ],
+      bottomNavigationBar: BottomAppBar(
+        color: Colors.grey[300],
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: const [
+              Icon(Icons.note, color: Colors.black),
+              Icon(Icons.home, color: Colors.black),
+              Icon(Icons.exit_to_app, color: Colors.black),
+            ],
+          ),
         ),
       ),
     );

--- a/mobidic_flutter/lib/account_find_home.dart
+++ b/mobidic_flutter/lib/account_find_home.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+class AccountFindHome extends StatelessWidget {
+  const AccountFindHome({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("계정 찾기"),
+        centerTitle: true,
+        backgroundColor: Colors.white,
+        foregroundColor: Colors.black,
+        elevation: 0,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 40),
+        child: Row(
+          children: [
+            Expanded(
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.pushNamed(context, '/find/id');
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.deepPurple[100],
+                  foregroundColor: Colors.deepPurple,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(24),
+                  ),
+                ),
+                child: const Text("아이디 찾기"),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.pushNamed(context, '/find/pw');
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.deepPurple[100],
+                  foregroundColor: Colors.deepPurple,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(24),
+                  ),
+                ),
+                child: const Text("비밀번호 재설정"),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobidic_flutter/lib/account_find_home.dart
+++ b/mobidic_flutter/lib/account_find_home.dart
@@ -13,42 +13,71 @@ class AccountFindHome extends StatelessWidget {
         foregroundColor: Colors.black,
         elevation: 0,
       ),
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 40),
-        child: Row(
-          children: [
-            Expanded(
-              child: ElevatedButton(
-                onPressed: () {
-                  Navigator.pushNamed(context, '/find/id');
-                },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.deepPurple[100],
-                  foregroundColor: Colors.deepPurple,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(24),
+      body: Container(
+        width: double.infinity,
+        height: double.infinity,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              Color(0xFFb2ebf2),
+              Color(0xFF81d4fa),
+              Color(0xFF4fc3f7),
+            ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 40),
+          child: Row(
+            children: [
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.pushNamed(context, '/find/id');
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.deepPurple[100],
+                    foregroundColor: Colors.deepPurple,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(24),
+                    ),
                   ),
+                  child: const Text("아이디 찾기"),
                 ),
-                child: const Text("아이디 찾기"),
               ),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: ElevatedButton(
-                onPressed: () {
-                  Navigator.pushNamed(context, '/find/pw');
-                },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.deepPurple[100],
-                  foregroundColor: Colors.deepPurple,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(24),
+              const SizedBox(width: 12),
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.pushNamed(context, '/find/pw');
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.deepPurple[100],
+                    foregroundColor: Colors.deepPurple,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(24),
+                    ),
                   ),
+                  child: const Text("비밀번호 찾기"),
                 ),
-                child: const Text("비밀번호 재설정"),
               ),
-            ),
-          ],
+            ],
+          ),
+        ),
+      ),
+      bottomNavigationBar: BottomAppBar(
+        color: Colors.grey[300],
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: const [
+              Icon(Icons.note, color: Colors.black),
+              Icon(Icons.home, color: Colors.black),
+              Icon(Icons.exit_to_app, color: Colors.black),
+            ],
+          ),
         ),
       ),
     );

--- a/mobidic_flutter/lib/find_id_page.dart
+++ b/mobidic_flutter/lib/find_id_page.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+class FindIdPage extends StatefulWidget {
+  const FindIdPage({super.key});
+
+  @override
+  State<FindIdPage> createState() => _FindIdPageState();
+}
+
+class _FindIdPageState extends State<FindIdPage> {
+  final nameController = TextEditingController();
+  final emailController = TextEditingController();
+
+  void tryFindId() {
+    String name = nameController.text.trim();
+    String email = emailController.text.trim();
+
+    // 예시: 고정된 더미 계정
+    if (name == "yjs" && email == "junseok@test.com") {
+      showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text("아이디 찾기 결과"),
+          content: const Text("당신의 아이디는: junseok123"),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text("확인"),
+            )
+          ],
+        ),
+      );
+    } else {
+      showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text("정보 확인 실패"),
+          content: const Text("등록되지 않은 계정입니다."),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text("다시 시도"),
+            )
+          ],
+        ),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    nameController.dispose();
+    emailController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text("아이디 찾기")),
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: nameController,
+              decoration: const InputDecoration(labelText: "본명을 입력하세요."),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: emailController,
+              decoration: const InputDecoration(labelText: "가입한 이메일을 입력하세요."),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: tryFindId,
+              child: const Text("아이디 찾기"),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobidic_flutter/lib/find_id_page.dart
+++ b/mobidic_flutter/lib/find_id_page.dart
@@ -15,7 +15,6 @@ class _FindIdPageState extends State<FindIdPage> {
     String name = nameController.text.trim();
     String email = emailController.text.trim();
 
-    // 예시: 고정된 더미 계정
     if (name == "yjs" && email == "junseok@test.com") {
       showDialog(
         context: context,
@@ -58,25 +57,55 @@ class _FindIdPageState extends State<FindIdPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text("아이디 찾기")),
-      body: Padding(
-        padding: const EdgeInsets.all(24.0),
-        child: Column(
-          children: [
-            TextField(
-              controller: nameController,
-              decoration: const InputDecoration(labelText: "본명을 입력하세요."),
-            ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: emailController,
-              decoration: const InputDecoration(labelText: "가입한 이메일을 입력하세요."),
-            ),
-            const SizedBox(height: 24),
-            ElevatedButton(
-              onPressed: tryFindId,
-              child: const Text("아이디 찾기"),
-            ),
-          ],
+      body: Container(
+        width: double.infinity,
+        height: double.infinity,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              Color(0xFFb2ebf2),
+              Color(0xFF81d4fa),
+              Color(0xFF4fc3f7),
+            ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            children: [
+              TextField(
+                controller: nameController,
+                decoration: const InputDecoration(labelText: "본명을 입력하세요."),
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: emailController,
+                decoration: const InputDecoration(labelText: "가입한 이메일을 입력하세요."),
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: tryFindId,
+                child: const Text("아이디 찾기"),
+              ),
+              const SizedBox(height: 40),
+            ],
+          ),
+        ),
+      ),
+      bottomNavigationBar: BottomAppBar(
+        color: Colors.grey[300],
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: const [
+              Icon(Icons.note, color: Colors.black),
+              Icon(Icons.home, color: Colors.black),
+              Icon(Icons.exit_to_app, color: Colors.black),
+            ],
+          ),
         ),
       ),
     );

--- a/mobidic_flutter/lib/find_pw_page.dart
+++ b/mobidic_flutter/lib/find_pw_page.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'dart:async';
+
+class FindPwPage extends StatefulWidget {
+  const FindPwPage({super.key});
+
+  @override
+  State<FindPwPage> createState() => _FindPwPageState();
+}
+
+class _FindPwPageState extends State<FindPwPage> {
+  final emailController = TextEditingController();
+  int attemptCount = 0;
+  bool isLocked = false;
+  String errorMessage = "";
+
+  void tryFindPw() {
+    if (isLocked) return;
+
+    String email = emailController.text.trim();
+
+    setState(() {
+      attemptCount++;
+    });
+
+    if (attemptCount > 5) {
+      setState(() {
+        isLocked = true;
+        errorMessage = "시도 횟수 5회를 초과했습니다. 3분 후, 다시 시도해주세요.";
+      });
+
+      Timer(const Duration(minutes: 3), () {
+        setState(() {
+          isLocked = false;
+          attemptCount = 0;
+          errorMessage = "";
+        });
+      });
+
+      return;
+    }
+
+    if (email == "junseok@test.com") {
+      showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text("비밀번호 재설정"),
+          content: const Text("이메일로 재설정 메일이 발송되었습니다."),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text("확인"),
+            )
+          ],
+        ),
+      );
+    } else {
+      setState(() {
+        errorMessage = "등록되지 않은 이메일 입니다.";
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    emailController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text("비밀번호 찾기")),
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: emailController,
+              decoration: const InputDecoration(labelText: "가입한 이메일을 입력하세요."),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: isLocked ? null : tryFindPw,
+              child: const Text("비밀번호 찾기"),
+            ),
+            const SizedBox(height: 12),
+            if (errorMessage.isNotEmpty)
+              Text(
+                errorMessage,
+                style: const TextStyle(color: Colors.red),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobidic_flutter/lib/find_pw_page.dart
+++ b/mobidic_flutter/lib/find_pw_page.dart
@@ -44,8 +44,8 @@ class _FindPwPageState extends State<FindPwPage> {
       showDialog(
         context: context,
         builder: (_) => AlertDialog(
-          title: const Text("비밀번호 재설정"),
-          content: const Text("이메일로 재설정 메일이 발송되었습니다."),
+          title: const Text("비밀번호 찾기"),
+          content: const Text("당신의 비밀벊호는: testpassword입니다."),
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(context),
@@ -71,26 +71,56 @@ class _FindPwPageState extends State<FindPwPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text("비밀번호 찾기")),
-      body: Padding(
-        padding: const EdgeInsets.all(24.0),
-        child: Column(
-          children: [
-            TextField(
-              controller: emailController,
-              decoration: const InputDecoration(labelText: "가입한 이메일을 입력하세요."),
-            ),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: isLocked ? null : tryFindPw,
-              child: const Text("비밀번호 찾기"),
-            ),
-            const SizedBox(height: 12),
-            if (errorMessage.isNotEmpty)
-              Text(
-                errorMessage,
-                style: const TextStyle(color: Colors.red),
+      body: Container(
+        width: double.infinity,
+        height: double.infinity,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              Color(0xFFb2ebf2),
+              Color(0xFF81d4fa),
+              Color(0xFF4fc3f7),
+            ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            children: [
+              TextField(
+                controller: emailController,
+                decoration: const InputDecoration(labelText: "가입한 이메일을 입력하세요."),
               ),
-          ],
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: isLocked ? null : tryFindPw,
+                child: const Text("비밀번호 찾기"),
+              ),
+              const SizedBox(height: 12),
+              if (errorMessage.isNotEmpty)
+                Text(
+                  errorMessage,
+                  style: const TextStyle(color: Colors.red),
+                ),
+              const SizedBox(height: 40),
+            ],
+          ),
+        ),
+      ),
+      bottomNavigationBar: BottomAppBar(
+        color: Colors.grey[300],
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: const [
+              Icon(Icons.note, color: Colors.black),
+              Icon(Icons.home, color: Colors.black),
+              Icon(Icons.exit_to_app, color: Colors.black),
+            ],
+          ),
         ),
       ),
     );

--- a/mobidic_flutter/lib/main.dart
+++ b/mobidic_flutter/lib/main.dart
@@ -1,23 +1,33 @@
 import 'package:flutter/material.dart';
-import 'package:mobidic_flutter/login_UI.dart';
+import 'Log_in_page.dart';
+import 'Sign_up_page.dart';
+import 'find_id_page.dart';
+import 'find_pw_page.dart';
+import 'account_find_home.dart'; // 계정 찾기 선택 화면
+import 'ox_quiz.dart';
+import 'fill_blank.dart';
+import 'dictation.dart';
 
-import 'OX_Quiz.dart';
-import 'join_UI.dart';
-
-void main() => runApp(MyApp());
+void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Whale Login',
-      theme: ThemeData(primarySwatch: Colors.blue),
+      title: 'Mobidic 로그인',
       debugShowCheckedModeBanner: false,
-      initialRoute: '/',
+      initialRoute: '/', // 앱 실행 시 LoginPage부터 시작
       routes: {
-        '/': (context) =>  LoginPage(),
+        '/': (context) => LoginPage(),
         '/signup': (context) => SignUpPage(),
-        '/oxquiz': (context) => OxQuizPage(),
+        '/find': (context) => const AccountFindHome(),
+        '/find/id': (context) => const FindIdPage(),
+        '/find/pw': (context) => const FindPwPage(),
+        '/quiz': (context) => const OXQuizPage(),
+        '/fillblank': (context) => const FillBlankPage(),
+        '/dictation': (context) => const DictationQuizPage(),
       },
     );
   }


### PR DESCRIPTION
 형님 제가 잘못해서 푸시를 2번 한 것 같습니다...죄송합니다..그리고  파닉스 UI 는 현재 구현 진행 중입니다.
컨벤션 'fix' 코드 보시면 될 것 같습니다. 민이랑 로그인 화면 UI에 맞추어 배경 설정하고 다듬었습니다. 
 추가로, 화면 하단이 너무 허전해서 앱들을 찾아봤는데 하단 버튼을 통해 메인화면이나, 단어장, 로그아웃이 있는게 편리해 보여서 아이콘 추가해서 디자인 해봤습니다. 민이 메인화면, 단어장 코드가 제 local/feature/frontend엔 없어서 아직 아이콘 누르면 화면 이동하는 것은 아직 구현하지 못했습니다. 파닉스 UI는 제가 내일까지 구현해서 보여드리겠습니다.

[fix:아이디/비번 찾기 화면 배경삽입]

[fix:받아쓰기 퀴즈 배경삽입]

[fix:빈칸채우기 퀴즈 배경삽입]

[fix:ID찾기 화면 배경삽입]


[fix:PW찾기 화면 배경삽입]

[fix:PW찾기 화면 배경삽입]

[fix:OX퀴즈 배경삽입]

[fix:회원가입 화면 배경삽입]